### PR TITLE
Fix typo in upgrade manual

### DIFF
--- a/UPGRADE Manual
+++ b/UPGRADE Manual
@@ -3,13 +3,13 @@ Upgrade crossterm 0.2 to 0.2.1
 Namespaces:
 I have changed the namespaces. I found the namsespaces to long so I have shoted them like the followin:
 
-Old: crossterm::crosster_style 
+Old: crossterm::crossterm_style 
 New: crossterm::style
 
-Old: crossterm::crosster_terminal
+Old: crossterm::crossterm_terminal
 New: crossterm::terminal
 
-Old: crossterm::crosster_cursor 
+Old: crossterm::crossterm_cursor 
 New: crossterm::cursor
 
 Method names that changed [Issue 4](https://github.com/TimonPost/crossterm/issues/4): 


### PR DESCRIPTION
By the way, I think this should not have been a patch version. My build process just broke :) Appreciate the namespace changes though.