### PR TITLE
Fix set_size for ansi terminals

### DIFF
--- a/src/modules/terminal/ansi_terminal.rs
+++ b/src/modules/terminal/ansi_terminal.rs
@@ -48,7 +48,7 @@ impl ITerminal for AnsiTerminal {
     }
 
     fn set_size(&self, width: i16, height: i16, stdout: &Arc<TerminalOutput>) {
-        stdout.write_string(format!(csi!("8;{};{}t"), width, height));
+        stdout.write_string(format!(csi!("8;{};{}t"), height, width));
     }
 
     fn exit(&self,stdout: &Arc<TerminalOutput>) {


### PR DESCRIPTION
Height should come first in the escape code as shown [here](https://apple.stackexchange.com/questions/33736/can-a-terminal-window-be-resized-with-a-terminal-command) or more formally [here](http://invisible-island.net/xterm/ctlseqs/ctlseqs.html) (ctrl+f for `CSI Ps ; Ps ; Ps t` and scroll down to `Ps = 8`).