### PR TITLE
Fix `AnsiOutput` write methods claiming zero bytes were written

### DIFF
--- a/src/modules/output/ansi_output.rs
+++ b/src/modules/output/ansi_output.rs
@@ -14,25 +14,23 @@ pub struct AnsiOutput {
 
 impl IStdout for AnsiOutput {
    fn write_str(&self, string: &str) -> io::Result<usize> {
-       let out = &self.handle;
-       let mut handle = out.lock();
-        write!(handle, "{}", string)?;
-       handle.flush();
-        Ok(0)
+        let out = &self.handle;
+        let mut handle = out.lock();
+        let amt = handle.write(string.as_bytes())?;
+        handle.flush()?;
+        Ok(amt)
     }
 
     fn write(&self, buf: &[u8]) -> io::Result<usize> {
         let out = &self.handle;
         let mut handle = out.lock();
-        handle.write(buf)?;
-        Ok(0)
+        handle.write(buf)
     }
 
     fn flush(&self) -> io::Result<()> {
         let out = &self.handle;
         let mut handle = out.lock();
-        handle.flush();
-        Ok(())
+        handle.flush()
     }
 
     fn as_any(&self) -> &Any {


### PR DESCRIPTION
Currently, the implementation of `IStdout` for `AnsiOutput`always returns `Ok(0)` when a write completes successfully. 

This behaviour is incorrect, as these methods are used elsewhere to implement `std::io::Write`, which [expects  the writer to return the number of bytes written](https://doc.rust-lang.org/std/io/trait.Write.html#tymethod.write). This means that the implementation of `Write` for `crossterm::Terminal` doesn't play nice with the `write!` macro (and other consumers of the `Write` trait), causing uses of `write!` to panic with the message "failed to write whole buffer". (see mgattozzi/ysh#12).

This branch changes these methods to correctly return the number of bytes written, fixing the panics.