### PR TITLE
Make example less confusing by using the described colours.

### DIFF
--- a/examples/examples.rs
+++ b/examples/examples.rs
@@ -14,12 +14,12 @@ extern crate crossterm;
 //mod some_types;
 //mod terminal;
 
-use crossterm::style::{style, Color, Attribute};
+use crossterm::style::{style, Color};
 
 fn main() {
     let styled_object = style("'Red' text on 'White' background")
-        .with(Color::Rgb { r: 34, g: 80, b: 23 })
-        .on(Color::Rgb { r: 34, g: 80, b: 23 });
+        .with(Color::Rgb { r: 0xFF, g: 0, b: 0 })
+        .on(Color::Rgb { r: 0xFF, g: 0xFF, b: 0xFF });
 
     println!("{}", styled_object);
 }


### PR DESCRIPTION
The main example said it was printing out 'Red Text on a White background', but the whole thing was green.
I thought the terminal encoding was broken...