### PR TITLE
feat: make error module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,5 +342,6 @@ pub use self::style::{
     TerminalColor,
 };
 pub use self::terminal::{terminal, Terminal};
+pub use common::error;
 pub use common::screen::{AlternateScreen, Screen};
 pub use common::Crossterm;


### PR DESCRIPTION
With the recent introduction of the explicit error handling #69, `Result` and `ErrorKind` types where added as part of the signature of some functions of the public api. In order to use this crate within an other one (e.g tui in my case), the error might need to be converted which is to my understanding impossible in the current state since those types are private. Thus this change makes the error module public. 