### PR TITLE
Raw (blocking) read_char for unix

### DIFF
--- a/crossterm_input/src/input/unix_input.rs
+++ b/crossterm_input/src/input/unix_input.rs
@@ -1,7 +1,7 @@
 //! This is a UNIX specific implementation for input related action.
 
 use super::*;
-use crate::sys::unix::{get_tty, read_char};
+use crate::sys::unix::{get_tty, read_char, read_char_raw};
 
 use crossterm_utils::TerminalOutput;
 use std::char;
@@ -16,8 +16,17 @@ impl UnixInput {
 }
 
 impl ITerminalInput for UnixInput {
-    fn read_char(&self, __stdout: &Option<&Arc<TerminalOutput>>) -> io::Result<char> {
-        read_char()
+    fn read_char(&self, stdout: &Option<&Arc<TerminalOutput>>) -> io::Result<char> {
+        let is_raw_screen = match stdout {
+            Some(output) => output.is_in_raw_mode,
+            None => false,
+        };
+
+        if is_raw_screen {
+            read_char_raw()
+        } else {
+            read_char()
+        }
     }
 
     fn read_async(&self, __stdout: &Option<&Arc<TerminalOutput>>) -> AsyncReader {

--- a/crossterm_input/src/sys/unix.rs
+++ b/crossterm_input/src/sys/unix.rs
@@ -68,3 +68,47 @@ pub fn read_char() -> io::Result<char> {
 
     rv
 }
+
+fn get_tty_fd() -> io::Result<i32> {
+    let fd = unsafe {
+        if libc::isatty(libc::STDIN_FILENO) == 1 {
+            libc::STDIN_FILENO
+        } else {
+            let tty_f = fs::File::open("/dev/tty")?;
+            tty_f.as_raw_fd()
+        }
+    };
+    Ok(fd)
+}
+
+pub fn read_char_raw() -> io::Result<char> {
+    let mut buf = [0u8; 20];
+
+    let fd = get_tty_fd()?;
+
+    // read input and convert it to char
+    let rv = unsafe {
+        let read = libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, 20);
+
+        if read < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            let mut pressed_char = Ok(' ');
+
+            if let Ok(s) = ::std::str::from_utf8(&buf[..read as usize]) {
+                if let Some(c) = s.chars().next() {
+                    pressed_char = Ok(c);
+                }
+            } else {
+                pressed_char = Err(io::Error::new(
+                    io::ErrorKind::Interrupted,
+                    "Could not parse char to utf8 char",
+                ));
+            }
+
+            pressed_char
+        }
+    };
+
+    rv
+}


### PR DESCRIPTION
The current implementation of read_char seems only suited for non-raw mode.
This PR adds a read_char_raw() function so that raw terminals can call read_char without backed-up characters printing, and allowing the calling code to directly handle ctrl-c input.