### PR TITLE
included methods to enable mouse events for windows and unix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
 .idea/
+.vscode/
 **/*.rs.bk
 Cargo.lock

--- a/crossterm_input/src/input/input.rs
+++ b/crossterm_input/src/input/input.rs
@@ -4,7 +4,7 @@
 use super::*;
 use std::{thread, time::Duration};
 
-use crossterm_utils::TerminalOutput;
+use crossterm_utils::{TerminalOutput, Result};
 
 /// Allows you to preform actions with the < option >.
 ///
@@ -251,6 +251,28 @@ impl<'stdout> TerminalInput<'stdout> {
             // some sleeping time so that we don't 'dos' our cpu.
             thread::sleep(Duration::from_millis(10));
         }
+    }
+
+    /// Enable mouse events to be captured.
+    ///
+    /// ```rust
+    /// let input = input();
+    /// input.enable_mouse();
+    /// ```
+    pub fn enable_mouse(&self) -> Result<()> {
+        // TODO: needs a test
+        self.terminal_input.enable_mouse(&self.stdout)
+    }
+
+    /// Disable mouse events to be captured.
+    ///
+    /// ```rust
+    /// let input = input();
+    /// input.disable_mouse();
+    /// ```
+    pub fn disable_mouse(&self) -> Result<()> {
+        // TODO: needs a test
+        self.terminal_input.disable_mouse(&self.stdout)
     }
 }
 


### PR DESCRIPTION
Getting mouse events to be enabled and disabled in crossterm_input. This is to support Input Expansion: https://github.com/TimonPost/crossterm/issues/81

Next steps/branch:
* translate windows inputs into csi / vt sequences
* update windows_input read_async to send the translated vt_sequences into the channel
* add a parse_event method to handle the vt sequences from AsyncReader