### PR TITLE
Get the style example compiling again

### DIFF
--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -48,7 +48,7 @@ pub fn move_down() {
 }
 
 /// Save and reset cursor position | demonstration..
-pub fn safe_and_reset_position() {
+pub fn save_and_reset_position() {
     let cursor = cursor();
 
     // Goto X: 5 Y: 5

--- a/examples/style.rs
+++ b/examples/style.rs
@@ -3,7 +3,7 @@
 //!
 extern crate crossterm;
 
-use self::crossterm::{style, Color};
+use self::crossterm::{style, Color, color};
 
 /// print some red font | demonstration.
 pub fn paint_foreground() {
@@ -229,4 +229,10 @@ pub fn print_supported_colors() {
             style(format!("White : \t {}", i)).on(Color::AnsiValue(i as u8))
         );
     }
+}
+
+fn main() {
+    print_all_background_colors();
+    print_all_foreground_colors();
+    print_font_with_attributes();
 }


### PR DESCRIPTION
The style example's main got nuked in the refactor. This brings it back and gets it running again. Also fixed a typo in the cursor example.