### PR TITLE
Fixed some minor things.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,10 @@ members = [
 
 [dependencies]
 crossterm_screen =   { optional = true, version = "0.2.1" }
-crossterm_cursor =   { optional = true, version = "0.2.1" }
-crossterm_terminal = { optional = true, version = "0.2.1" }
+crossterm_cursor =   { optional = true, path = "./crossterm_cursor" }
+crossterm_terminal = { optional = true, path = "./crossterm_terminal" }
 crossterm_style =    { optional = true, version = "0.3.1" }
-crossterm_input =    { optional = true, version = "0.3.1" }
+crossterm_input =    { optional = true, path = "./crossterm_input" }
 crossterm_utils =    { optional = false, version = "0.2.1" }
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossterm"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["T. Post"]
 description = "An crossplatform terminal library for manipulating terminals."
 repository = "https://github.com/TimonPost/crossterm"
@@ -33,7 +33,7 @@ members = [
 
 [dependencies]
 crossterm_screen =   { optional = true, version = "0.2.1" }
-crossterm_cursor =   { optional = true, path = "./crossterm_cursor" }
+crossterm_cursor =   { optional = true, version = "0.2.1" }
 crossterm_terminal = { optional = true, path = "./crossterm_terminal" }
 crossterm_style =    { optional = true, version = "0.3.1" }
 crossterm_input =    { optional = true, path = "./crossterm_input" }

--- a/crossterm_cursor/src/sys/unix.rs
+++ b/crossterm_cursor/src/sys/unix.rs
@@ -70,6 +70,7 @@ pub fn pos() -> io::Result<(u16, u16)> {
 
     // Expect `R`
     let res = if c == 'R' {
+        // subtract one to get 0-based coords
         Ok(((cols - 1) as u16, (rows - 1) as u16))
     } else {
         return Err(Error::new(ErrorKind::Other, "test"));

--- a/crossterm_input/CHANGELOG.md
+++ b/crossterm_input/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Changes crossterm_input 0.3.2
+- Fixed some special key combination detections for UNIX systems
+- Windows mouse input event position was 0-based and should be 1-based
+
+# Changes crossterm_input 0.3.1
+- Updated crossterm_utils 
+
 # Changes crossterm_input 0.3
 - Removed `TerminalInput::from_output()` 
 

--- a/crossterm_input/Cargo.toml
+++ b/crossterm_input/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossterm_input"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["T. Post"]
 description = "A cross-platform library for reading userinput."
 repository = "https://github.com/TimonPost/crossterm"

--- a/crossterm_input/src/input/windows_input.rs
+++ b/crossterm_input/src/input/windows_input.rs
@@ -291,16 +291,16 @@ fn handle_mouse_event(event: &MouseEvent, seq: &mut Vec<u8>) {
     // mimicks the behavior; additionally, in xterm, mouse move is only handled when a
     // mouse button is held down (ie. mouse drag)
 
-    let cxbs: Vec<u8> = event
+    let cxbs: Vec<u8> = (event
         .mouse_position
-        .x
+        .x + 1) /* windows positions are 0 based and ansi codes 1. */
         .to_string()
         .chars()
         .map(|d| d as u8)
         .collect();
-    let cybs: Vec<u8> = event
+    let cybs: Vec<u8> = (event
         .mouse_position
-        .y
+        .y + 1) /* windows positions are 0 based and ansi codes 1. */
         .to_string()
         .chars()
         .map(|d| d as u8)

--- a/crossterm_input/src/input/windows_input.rs
+++ b/crossterm_input/src/input/windows_input.rs
@@ -291,20 +291,18 @@ fn handle_mouse_event(event: &MouseEvent, seq: &mut Vec<u8>) {
     // mimicks the behavior; additionally, in xterm, mouse move is only handled when a
     // mouse button is held down (ie. mouse drag)
 
-    let cxbs: Vec<u8> = (event
-        .mouse_position
-        .x + 1) /* windows positions are 0 based and ansi codes 1. */
-        .to_string()
-        .chars()
-        .map(|d| d as u8)
-        .collect();
-    let cybs: Vec<u8> = (event
-        .mouse_position
-        .y + 1) /* windows positions are 0 based and ansi codes 1. */
-        .to_string()
-        .chars()
-        .map(|d| d as u8)
-        .collect();
+    let cxbs: Vec<u8> =
+        (event.mouse_position.x + 1) /* windows positions are 0 based and ansi codes 1. */
+            .to_string()
+            .chars()
+            .map(|d| d as u8)
+            .collect();
+    let cybs: Vec<u8> =
+        (event.mouse_position.y + 1) /* windows positions are 0 based and ansi codes 1. */
+            .to_string()
+            .chars()
+            .map(|d| d as u8)
+            .collect();
 
     // TODO (@imdaveho): check if linux only provides coords for visible terminal window vs the total buffer
 

--- a/crossterm_terminal/CHANGELOG.md
+++ b/crossterm_terminal/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Changes crossterm_style 0.2.2
+- Terminal size Linux was not 0-based.
+- Made FreeBSD compile
+
 # Changes crossterm_style 0.2
 - Removed `Terminal:from_output()` 
 

--- a/crossterm_terminal/Cargo.toml
+++ b/crossterm_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crossterm_terminal"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["T. Post"]
 description = "A cross-platform library for doing terminal related actions."
 repository = "https://github.com/TimonPost/crossterm"

--- a/crossterm_terminal/src/sys/unix.rs
+++ b/crossterm_terminal/src/sys/unix.rs
@@ -26,7 +26,7 @@ pub fn get_terminal_size() -> (u16, u16) {
         ws_ypixel: 0,
     };
 
-    let r = unsafe { ioctl(STDOUT_FILENO, TIOCGWINSZ, &us) };
+    let r = unsafe { ioctl(STDOUT_FILENO, TIOCGWINSZ.into(), &us) };
 
     if r == 0 {
         // because crossterm works starts counting at 0 and unix terminal starts at cell 1 you have subtract one to get 0-based results.

--- a/crossterm_terminal/src/sys/unix.rs
+++ b/crossterm_terminal/src/sys/unix.rs
@@ -30,7 +30,7 @@ pub fn get_terminal_size() -> (u16, u16) {
 
     if r == 0 {
         // because crossterm works starts counting at 0 and unix terminal starts at cell 1 you have subtract one to get 0-based results.
-        (us.cols, us.rows)
+        (us.cols - 1, us.rows - 1)
     } else {
         (0, 0)
     }

--- a/crossterm_winapi/src/console.rs
+++ b/crossterm_winapi/src/console.rs
@@ -165,7 +165,10 @@ impl Console {
     }
 
     pub fn read_console_input(&self) -> Result<(u32, Vec<InputRecord>)> {
-        let mut buf: [INPUT_RECORD; 0x1000] = unsafe { zeroed() };
+        // Large buffers can overflow max heap size (?) and lead to errno 8
+        // "Not enough storage is available to process this command."
+        // It can be reproduced at Windows 7 i686 with `0x1000` buffer size.
+        let mut buf: [INPUT_RECORD; 0x800] = unsafe { zeroed() };
         let mut size = 0;
 
         if !is_true(unsafe {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Changes crossterm 0.9.1
+- Terminal size linux was not 0-based.
+- Windows mouse input event position was 0-based ans should be 1-based
+- Result, ErrorKind are made re-exported
+
+## Changes crossterm 0.9.1
+- Fixed libc compile error
+
 ## Changes crossterm 0.9.0
 This release is all about moving to a stabilized API for 1.0.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,12 +1,14 @@
-## Changes crossterm 0.9.1
-- Terminal size linux was not 0-based.
+## Changes crossterm 0.9.2
+- Terminal size linux was not 0-based
 - Windows mouse input event position was 0-based ans should be 1-based
 - Result, ErrorKind are made re-exported
+- Fixed some special key combination detections for UNIX systems
+- Made FreeBSD compile
 
 ## Changes crossterm 0.9.1
 - Fixed libc compile error
 
-## Changes crossterm 0.9.0
+## Changes crossterm 0.9.0 (yanked)
 This release is all about moving to a stabilized API for 1.0.
 
 - Major refactor and cleanup.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,4 +29,5 @@ pub use self::crossterm_style::{
 #[cfg(feature = "terminal")]
 pub use self::crossterm_terminal::{terminal, ClearType, Terminal};
 
+pub use self::crossterm_utils::{Result, ErrorKind};
 pub use self::crossterm::Crossterm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,5 +29,5 @@ pub use self::crossterm_style::{
 #[cfg(feature = "terminal")]
 pub use self::crossterm_terminal::{terminal, ClearType, Terminal};
 
-pub use self::crossterm_utils::{Result, ErrorKind};
 pub use self::crossterm::Crossterm;
+pub use self::crossterm_utils::{ErrorKind, Result};


### PR DESCRIPTION
- Terminal size Linux was not 0-based.
- Windows mouse input event position was 0-based and should be 1-based
- Result, ErrorKind are made re-exported
- Fixed some special key combination detections for UNIX systems
- Made FreeBSD compile.