### PR TITLE
Windows and FreeBSD compatibility issues

### DIFF
--- a/crossterm_terminal/src/sys/unix.rs
+++ b/crossterm_terminal/src/sys/unix.rs
@@ -26,7 +26,7 @@ pub fn get_terminal_size() -> (u16, u16) {
         ws_ypixel: 0,
     };
 
-    let r = unsafe { ioctl(STDOUT_FILENO, TIOCGWINSZ, &us) };
+    let r = unsafe { ioctl(STDOUT_FILENO, TIOCGWINSZ.into(), &us) };
 
     if r == 0 {
         // because crossterm works starts counting at 0 and unix terminal starts at cell 1 you have subtract one to get 0-based results.

--- a/crossterm_winapi/src/console.rs
+++ b/crossterm_winapi/src/console.rs
@@ -165,7 +165,10 @@ impl Console {
     }
 
     pub fn read_console_input(&self) -> Result<(u32, Vec<InputRecord>)> {
-        let mut buf: [INPUT_RECORD; 0x1000] = unsafe { zeroed() };
+        // Large buffers can overflow max heap size (?) and lead to errno 8
+        // "Not enough storage is available to process this command."
+        // It can be reproduced at Windows 7 i686 with `0x1000` buffer size.
+        let mut buf: [INPUT_RECORD; 0x800] = unsafe { zeroed() };
         let mut size = 0;
 
         if !is_true(unsafe {


### PR DESCRIPTION
As was discussed at Discord, here a two fixes:

1. Compilation failure for FreeBSD x86_64, as can be seen [here](https://travis-ci.org/svartalf/rust-battop/jobs/519607730) with fix same to one `termion` uses
2. Runtime fix for old Windows versions, which are may overflow the thread heap (I think?) with a too big buffer for input reading.
I've reproduced that bug with Windows 7 i686 in the VM, reducing buffer size in twice seems to remove the problem.

UPD: this PR targets `fixes` branch at the moment.