### PR TITLE
Eq for KeyEvent

### DIFF
--- a/crossterm_input/src/input/mod.rs
+++ b/crossterm_input/src/input/mod.rs
@@ -91,7 +91,7 @@ pub enum MouseButton {
 }
 
 /// Enum with different key or key combinations.
-#[derive(Debug, PartialOrd, PartialEq)]
+#[derive(Debug, PartialOrd, PartialEq, Eq)]
 pub enum KeyEvent {
     Backspace,
     Left,


### PR DESCRIPTION
Adds #[derive(Eq)] for KeyEvent.
I can add derives for Eq and Ord for the other event enums as well, since they all already derive PartialEq PartialOrd.