### PR TITLE
Fixes white/grey and adds dark grey

### DIFF
--- a/crossterm_style/src/ansi_color.rs
+++ b/crossterm_style/src/ansi_color.rs
@@ -41,7 +41,7 @@ impl ITerminalColor for AnsiColor {
     fn color_value(&self, colored: Colored) -> String {
         let mut ansi_value = String::new();
 
-        let mut color = Color::White;
+        let color;
 
         match colored {
             Colored::Fg(new_color) => {
@@ -58,6 +58,7 @@ impl ITerminalColor for AnsiColor {
 
         let color_val = match color {
             Color::Black => "5;0",
+            Color::DarkGrey => "5;8",
             Color::Red => "5;9",
             Color::DarkRed => "5;1",
             Color::Green => "5;10",
@@ -70,8 +71,8 @@ impl ITerminalColor for AnsiColor {
             Color::DarkMagenta => "5;5",
             Color::Cyan => "5;14",
             Color::DarkCyan => "5;6",
-            Color::Grey => "5;15",
-            Color::White => "5;7",
+            Color::White => "5;15",
+            Color::Grey => "5;7",
 
             Color::Rgb { r, g, b } => {
                 rgb_val = format!("2;{};{};{}", r, g, b);

--- a/crossterm_style/src/enums/color.rs
+++ b/crossterm_style/src/enums/color.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 #[derive(Debug, Copy, Clone)]
 pub enum Color {
     Black,
+    DarkGrey,
 
     Red,
     DarkRed,
@@ -24,8 +25,8 @@ pub enum Color {
     Cyan,
     DarkCyan,
 
-    Grey,
     White,
+    Grey,
     /// Color representing RGB-colors;
     /// r = red
     /// g = green
@@ -61,6 +62,7 @@ impl FromStr for Color {
 
         match src.as_ref() {
             "black" => Ok(Color::Black),
+            "dark_grey" => Ok(Color::DarkGrey),
             "red" => Ok(Color::Red),
             "dark_red" => Ok(Color::DarkRed),
             "green" => Ok(Color::Green),
@@ -73,8 +75,8 @@ impl FromStr for Color {
             "dark_magenta" => Ok(Color::DarkMagenta),
             "cyan" => Ok(Color::Cyan),
             "dark_cyan" => Ok(Color::DarkCyan),
-            "grey" => Ok(Color::Grey),
             "white" => Ok(Color::White),
+            "grey" => Ok(Color::Grey),
             _ => Ok(Color::White),
         }
     }

--- a/crossterm_style/src/lib.rs
+++ b/crossterm_style/src/lib.rs
@@ -80,6 +80,7 @@ where
 impl Colorize<&'static str> for &'static str {
     // foreground colors
     def_str_color!(fg_color: black => Color::Black);
+    def_str_color!(fg_color: dark_grey => Color::DarkGrey);
     def_str_color!(fg_color: red => Color::Red);
     def_str_color!(fg_color: dark_red => Color::DarkRed);
     def_str_color!(fg_color: green => Color::Green);
@@ -97,6 +98,7 @@ impl Colorize<&'static str> for &'static str {
 
     // background colors
     def_str_color!(bg_color: on_black => Color::Black);
+    def_str_color!(bg_color: on_dark_grey => Color::DarkGrey);
     def_str_color!(bg_color: on_red => Color::Red);
     def_str_color!(bg_color: on_dark_red => Color::DarkRed);
     def_str_color!(bg_color: on_green => Color::Green);

--- a/crossterm_style/src/styledobject.rs
+++ b/crossterm_style/src/styledobject.rs
@@ -83,6 +83,7 @@ impl<D: Display> Display for StyledObject<D> {
 impl<D: Display> Colorize<D> for StyledObject<D> {
     // foreground colors
     def_color!(fg_color: black => Color::Black);
+    def_color!(fg_color: dark_grey => Color::DarkGrey);
     def_color!(fg_color: red => Color::Red);
     def_color!(fg_color: dark_red => Color::DarkRed);
     def_color!(fg_color: green => Color::Green);
@@ -100,6 +101,7 @@ impl<D: Display> Colorize<D> for StyledObject<D> {
 
     // background colors
     def_color!(bg_color: on_black => Color::Black);
+    def_color!(bg_color: on_dark_grey => Color::DarkGrey);
     def_color!(bg_color: on_red => Color::Red);
     def_color!(bg_color: on_dark_red => Color::DarkRed);
     def_color!(bg_color: on_green => Color::Green);

--- a/crossterm_style/src/traits.rs
+++ b/crossterm_style/src/traits.rs
@@ -13,6 +13,7 @@ use std::fmt::Display;
 /// ```
 pub trait Colorize<D: Display> {
     fn black(self) -> StyledObject<D>;
+    fn dark_grey(self) -> StyledObject<D>;
     fn red(self) -> StyledObject<D>;
     fn dark_red(self) -> StyledObject<D>;
     fn green(self) -> StyledObject<D>;
@@ -29,6 +30,7 @@ pub trait Colorize<D: Display> {
     fn grey(self) -> StyledObject<D>;
 
     fn on_black(self) -> StyledObject<D>;
+    fn on_dark_grey(self) -> StyledObject<D>;
     fn on_red(self) -> StyledObject<D>;
     fn on_dark_red(self) -> StyledObject<D>;
     fn on_green(self) -> StyledObject<D>;

--- a/crossterm_style/src/winapi_color.rs
+++ b/crossterm_style/src/winapi_color.rs
@@ -99,6 +99,7 @@ impl ITerminalColor for WinApiColor {
             Colored::Fg(color) => {
                 winapi_color = match color {
                     Color::Black => 0,
+                    Color::DarkGrey => fg_intensity,
                     Color::Red => fg_intensity | fg_red,
                     Color::DarkRed => fg_red,
                     Color::Green => fg_intensity | fg_green,
@@ -111,8 +112,8 @@ impl ITerminalColor for WinApiColor {
                     Color::DarkMagenta => fg_red | fg_blue,
                     Color::Cyan => fg_intensity | fg_green | fg_blue,
                     Color::DarkCyan => fg_green | fg_blue,
-                    Color::Grey => fg_intensity,
-                    Color::White => fg_intensity | fg_red | fg_green | fg_blue,
+                    Color::White => fg_red | fg_green | fg_blue,
+                    Color::Grey => fg_intensity | fg_red | fg_green | fg_blue,
 
                     /* WinApi will be used for systems that do not support ANSI, those are windows version less then 10. RGB and 255 (AnsiBValue) colors are not supported in that case.*/
                     Color::Rgb { r: _, g: _, b: _ } => 0,
@@ -122,6 +123,7 @@ impl ITerminalColor for WinApiColor {
             Colored::Bg(color) => {
                 winapi_color = match color {
                     Color::Black => 0,
+                    Color::DarkGrey => bg_intensity,
                     Color::Red => bg_intensity | bg_red,
                     Color::DarkRed => bg_red,
                     Color::Green => bg_intensity | bg_green,
@@ -134,8 +136,8 @@ impl ITerminalColor for WinApiColor {
                     Color::DarkMagenta => bg_red | bg_blue,
                     Color::Cyan => bg_intensity | bg_green | bg_blue,
                     Color::DarkCyan => bg_green | bg_blue,
-                    Color::Grey => bg_intensity,
                     Color::White => bg_intensity | bg_red | bg_green | bg_blue,
+                    Color::Grey => bg_red | bg_green | bg_blue,
 
                     /* WinApi will be used for systems that do not support ANSI, those are windows version less then 10. RGB and 255 (AnsiBValue) colors are not supported in that case.*/
                     Color::Rgb { r: _, g: _, b: _ } => 0,

--- a/examples/style.rs
+++ b/examples/style.rs
@@ -26,6 +26,11 @@ pub fn print_all_foreground_colors_with_enum() {
         Attribute::Reset
     );
     println!(
+        "DarkGrey : \t\t      {} ■ {}\n",
+        Colored::Fg(Color::DarkGrey),
+        Attribute::Reset
+    );
+    println!(
         "Red : \t\t        {} ■ {}\n",
         Colored::Fg(Color::Red),
         Attribute::Reset
@@ -117,6 +122,11 @@ pub fn print_all_foreground_colors_with_method() {
         "■".black(),
         Attribute::Reset
     );
+    println!(
+        "DarkGrey : \t\t     {} {}\n",
+        "■".dark_grey(),
+        Attribute::Reset
+    );
     println!("Red : \t\t         {} {}\n", "■".red(), Attribute::Reset);
     println!(
         "DarkRed : \t\t     {} {}\n",
@@ -178,6 +188,11 @@ pub fn print_all_background_colors_with_enum() {
     println!(
         "Black : \t\t      {} ■ {}\n",
         Colored::Bg(Color::Black),
+        Attribute::Reset
+    );
+    println!(
+        "DarkGrey : \t\t      {} ■ {}\n",
+        Colored::Bg(Color::DarkGrey),
         Attribute::Reset
     );
     println!(
@@ -270,6 +285,11 @@ pub fn print_all_background_colors_with_method() {
     println!(
         "Black : \t\t       {} {}\n",
         "■".on_black(),
+        Attribute::Reset
+    );
+    println!(
+        "DarkGrey : \t\t       {} {}\n",
+        "■".on_dark_grey(),
         Attribute::Reset
     );
     println!(


### PR DESCRIPTION
The ANSI codes for white and grey seem to have been switched.
I also added the ANSI code for dark grey for completeness.
I saw you have an open PR against fdehau/tui-rs; if this change makes it in then the [corresponding line there](https://github.com/fdehau/tui-rs/blob/5f8dd3813509cd409dc51202e41d7d5a6f52246b/src/backend/crossterm.rs#L172) should be updated as well to correctly translate dark grey for the CrosstermBackend.