### PR TITLE
Fixing alternate screen initialization for ANSI-supporting Windows terminals

### DIFF
--- a/crossterm_screen/src/screen/alternate.rs
+++ b/crossterm_screen/src/screen/alternate.rs
@@ -40,10 +40,10 @@ impl AlternateScreen {
     pub fn to_alternate(raw_mode: bool) -> io::Result<AlternateScreen> {
         #[cfg(windows)]
         let command = if supports_ansi() {
-            Box::from(ToAlternateScreenCommand::new())
+            Box::from(sys::ToAlternateScreenCommand::new())
                 as Box<(dyn IAlternateScreenCommand + Sync + Send)>
         } else {
-            Box::from(sys::ToAlternateScreenCommand::new())
+            Box::from(ToAlternateScreenCommand::new())
                 as Box<(dyn IAlternateScreenCommand + Sync + Send)>
         };
 


### PR DESCRIPTION
As was mentioned by @MrYurihi [here](https://github.com/TimonPost/crossterm/issues/128#issuecomment-502357391).

I'm not quite sure yet if this change fixes my problem, still testing it.