### PR TITLE
Fix Unix terminal size

### DIFF
--- a/crossterm_terminal/src/sys/unix.rs
+++ b/crossterm_terminal/src/sys/unix.rs
@@ -16,10 +16,7 @@ pub fn get_terminal_size() -> (u16, u16) {
     let r = unsafe { ioctl(STDOUT_FILENO, TIOCGWINSZ.into(), &mut size) };
 
     if r == 0 {
-        // because crossterm works starts counting at 0
-        // and unix terminal starts at cell 1
-        // you have subtract one to get 0-based results.
-        (size.ws_col - 1, size.ws_row - 1)
+        (size.ws_co, size.ws_row)
     } else {
         (0, 0)
     }


### PR DESCRIPTION
In #162 you mentioned needing to add 1 to the windows code. The struct we're dealing with from Windows, [`CONSOLE_SCREEN_BUFFER_INFO`](https://docs.microsoft.com/en-us/windows/console/console-screen-buffer-info-str), doesn't mention anything about their `dwSize` returning anything special. I would assume it's going to be counting “from 0” meaning that a terminal with a width of 10 should report 10. I don't have access to Windows easily to test. The [original report](https://github.com/TimonPost/crossterm/issues/155) only mentioned Unix systems.

Fixes #162.