### PR TITLE
style: Update minimum crossterm_utils to 0.2.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,11 @@ members = [
 
 [dependencies]
 crossterm_screen =   { optional = true,  path = "./crossterm_screen", version = "^0.2" }
-crossterm_cursor =   { optional = true,  path = "./crossterm_cursor", version = "^0.2" }
-crossterm_terminal = { optional = true,  path = "./crossterm_terminal", version = "^0.2" }
+crossterm_cursor =   { optional = true,  path = "./crossterm_cursor", version = "^0.2.5" }
+crossterm_terminal = { optional = true,  path = "./crossterm_terminal", version = "^0.2.5" }
 crossterm_style =    { optional = true,  path = "./crossterm_style", version = "^0.4" }
 crossterm_input =    { optional = true,  path = "./crossterm_input", version = "^0.3" }
-crossterm_utils =    { optional = false, path = "./crossterm_utils", version = "^0.2"}
+crossterm_utils =    { optional = false, path = "./crossterm_utils", version = "^0.2.4"}
 
 [lib]
 name = "crossterm"

--- a/crossterm_cursor/Cargo.toml
+++ b/crossterm_cursor/Cargo.toml
@@ -16,4 +16,4 @@ winapi = { version =  "0.3.7", features = ["wincon","winnt","minwindef"] }
 crossterm_winapi = { path="../crossterm_winapi", version = "^0.1"}
 
 [dependencies]
-crossterm_utils = { path="../crossterm_utils", version = "^0.2"}
+crossterm_utils = { path="../crossterm_utils", version = "^0.2.4"}

--- a/crossterm_input/Cargo.toml
+++ b/crossterm_input/Cargo.toml
@@ -19,5 +19,5 @@ crossterm_winapi = { path="../crossterm_winapi", version = "^0.1"}
 libc = "0.2.51"
 
 [dependencies]
-crossterm_utils = {path="../crossterm_utils", version = "^0.2"}
+crossterm_utils = {path="../crossterm_utils", version = "^0.2.4"}
 crossterm_screen = {path="../crossterm_screen", version = "^0.2"}

--- a/crossterm_screen/Cargo.toml
+++ b/crossterm_screen/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-crossterm_utils = {path="../crossterm_utils", version = "^0.2"}
+crossterm_utils = {path="../crossterm_utils", version = "^0.2.4"}
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version =  "0.3.7", features = ["minwindef", "wincon"] }

--- a/crossterm_style/Cargo.toml
+++ b/crossterm_style/Cargo.toml
@@ -16,4 +16,4 @@ winapi = { version =  "0.3.7", features = ["wincon"] }
 crossterm_winapi = { path="../crossterm_winapi", version = "^0.1"}
 
 [dependencies]
-crossterm_utils = {path="../crossterm_utils", version = "^0.2"}
+crossterm_utils = {path="../crossterm_utils", version = "^0.2.4"}

--- a/crossterm_terminal/Cargo.toml
+++ b/crossterm_terminal/Cargo.toml
@@ -18,5 +18,5 @@ crossterm_winapi = { path="../crossterm_winapi", version = "^0.1"}
 libc = "0.2.51"
 
 [dependencies]
-crossterm_utils = {path="../crossterm_utils", version = "^0.2"}
+crossterm_utils = {path="../crossterm_utils", version = "^0.2.4"}
 crossterm_cursor = {path="../crossterm_cursor", version = "^0.2"}


### PR DESCRIPTION
```rust
   Compiling crossterm_utils v0.2.3
     Running `/usr/bin/rustc --crate-name crossterm_utils /usr/share/cargo/registry/crossterm_utils-0.2.3/src/lib.rs --color always --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C metadata=2e1ae350828fffa8 -C extra-filename=-2e1ae350828fffa8 --out-dir /home/brain/rpmbuild/BUILD/crossterm_style-0.4.0/target/release/deps -L dependency=/home/brain/rpmbuild/BUILD/crossterm_style-0.4.0/target/release/deps --extern libc=/home/brain/rpmbuild/BUILD/crossterm_style-0.4.0/target/release/deps/liblibc-c062ebaaf72c01e2.rlib --cap-lints allow -Copt-level=3 -Cdebuginfo=2 -Clink-arg=-Wl,-z,relro,-z,now -Ccodegen-units=1 -Copt-level=3 -Cdebuginfo=2 -Clink-arg=-Wl,-z,relro,-z,now -Ccodegen-units=1`
   Compiling crossterm_style v0.4.0 (/home/brain/rpmbuild/BUILD/crossterm_style-0.4.0)
     Running `/usr/bin/rustc --edition=2018 --crate-name crossterm_style src/lib.rs --color always --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C metadata=3aeb9ff65bf39d88 -C extra-filename=-3aeb9ff65bf39d88 --out-dir /home/brain/rpmbuild/BUILD/crossterm_style-0.4.0/target/release/deps -L dependency=/home/brain/rpmbuild/BUILD/crossterm_style-0.4.0/target/release/deps --extern crossterm_utils=/home/brain/rpmbuild/BUILD/crossterm_style-0.4.0/target/release/deps/libcrossterm_utils-2e1ae350828fffa8.rlib -Copt-level=3 -Cdebuginfo=2 -Clink-arg=-Wl,-z,relro,-z,now -Ccodegen-units=1 -Copt-level=3 -Cdebuginfo=2 -Clink-arg=-Wl,-z,relro,-z,now -Ccodegen-units=1`
error[E0432]: unresolved imports `crossterm_utils::impl_display`, `crossterm_utils::Command`
 --> src/color.rs:8:23
  |
8 | use crossterm_utils::{impl_display, Command, Result};
  |                       ^^^^^^^^^^^^  ^^^^^^^ no `Command` in the root
  |                       |
  |                       no `impl_display` in the root

error[E0432]: unresolved imports `crossterm_utils::execute`, `crossterm_utils::queue`, `crossterm_utils::Command`, `crossterm_utils::ExecutableCommand`, `crossterm_utils::QueueableCommand`
  --> src/lib.rs:32:27
   |
32 | pub use crossterm_utils::{execute, queue, Command, ExecutableCommand, QueueableCommand, Result};
   |                           ^^^^^^^  ^^^^^  ^^^^^^^  ^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^ no `QueueableCommand` in the root
   |                           |        |      |        |
   |                           |        |      |        no `ExecutableCommand` in the root
   |                           |        |      no `Command` in the root
   |                           |        no `queue` in the root
   |                           no `execute` in the root

```