### PR TITLE
Add optional derives for Serialize and Deserialize for public enums

### DIFF
--- a/crossterm_input/Cargo.toml
+++ b/crossterm_input/Cargo.toml
@@ -21,3 +21,4 @@ libc = "0.2.51"
 [dependencies]
 crossterm_utils = { path="../crossterm_utils", version = "0.2.4"}
 crossterm_screen = {path="../crossterm_screen", version = "0.2.4"}
+serde = { version = "1.0", features = ["derive"], optional = true }

--- a/crossterm_input/src/input/mod.rs
+++ b/crossterm_input/src/input/mod.rs
@@ -22,6 +22,9 @@ pub use self::windows_input::SyncReader;
 #[cfg(windows)]
 use self::windows_input::WindowsInput;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 pub use self::input::{input, TerminalInput};
 use crossterm_utils::Result;
 use std::io;
@@ -52,6 +55,7 @@ trait ITerminalInput {
 }
 
 /// Enum to specify which input event has occurred.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialOrd, PartialEq, Hash, Clone)]
 pub enum InputEvent {
     /// A single key or a combination is pressed.
@@ -65,6 +69,7 @@ pub enum InputEvent {
 }
 
 /// Enum to specify which mouse event has occurred.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialOrd, PartialEq, Hash, Clone, Copy)]
 pub enum MouseEvent {
     /// A mouse press has occurred, this contains the pressed button and the position of the press.
@@ -78,6 +83,7 @@ pub enum MouseEvent {
 }
 
 /// Enum to define mouse buttons.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialOrd, PartialEq, Hash, Clone, Copy)]
 pub enum MouseButton {
     /// Left mouse button
@@ -94,6 +100,7 @@ pub enum MouseButton {
 
 /// Enum with different key or key combinations.
 #[derive(Debug, PartialOrd, PartialEq, Eq, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum KeyEvent {
     Backspace,
     Left,

--- a/crossterm_style/Cargo.toml
+++ b/crossterm_style/Cargo.toml
@@ -17,3 +17,4 @@ crossterm_winapi = { path="../crossterm_winapi", version = "0.1.5"}
 
 [dependencies]
 crossterm_utils = { path="../crossterm_utils", version = "0.2.4"}
+serde = { version = "1.0.0", features = ["derive"], optional = true }

--- a/crossterm_style/src/enums/attribute.rs
+++ b/crossterm_style/src/enums/attribute.rs
@@ -1,5 +1,8 @@
 use std::fmt::Display;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Enum with the different attributes to style your test.
 ///
 /// There are few things to note:
@@ -28,6 +31,7 @@ use std::fmt::Display;
 /// println!("{}", style("Underlined text").underlined());
 /// println!("{}", style("Negative text").negative());
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub enum Attribute {
     /// All attributes off

--- a/crossterm_style/src/enums/color.rs
+++ b/crossterm_style/src/enums/color.rs
@@ -1,7 +1,11 @@
 use std::convert::AsRef;
 use std::str::FromStr;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Enum with the different colors to color your test and terminal.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub enum Color {
     // This resets the color.

--- a/crossterm_style/src/enums/colored.rs
+++ b/crossterm_style/src/enums/colored.rs
@@ -2,6 +2,9 @@ use crate::color::color;
 use crate::enums::Color;
 use std::fmt::Display;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Could be used to color the foreground or background color.
 ///
 /// `Colored::Fg` represents the foreground color.
@@ -22,6 +25,7 @@ use std::fmt::Display;
 /// let styled_text = "Red forground color on blue background.".red().on_blue();
 /// println!("{}", styled_text);
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub enum Colored {
     Fg(Color),

--- a/crossterm_terminal/Cargo.toml
+++ b/crossterm_terminal/Cargo.toml
@@ -20,3 +20,4 @@ libc = "0.2.51"
 [dependencies]
 crossterm_utils = { path="../crossterm_utils", version = "0.2.4"}
 crossterm_cursor = {path="../crossterm_cursor", version = "0.2.5"}
+serde = { version = "1.0.0", features = ["derive"], optional = true }

--- a/crossterm_terminal/src/terminal/mod.rs
+++ b/crossterm_terminal/src/terminal/mod.rs
@@ -16,7 +16,11 @@ pub use self::terminal::{terminal, Clear, ScrollDown, ScrollUp, SetSize, Termina
 
 use crossterm_utils::Result;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Enum with the different values to clear the terminal.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub enum ClearType {
     /// clear all cells in terminal.


### PR DESCRIPTION
This adds optional derives for serde Serialize and Deserialize to all public enums except ErrorKind. Please let me know if you have any objections against this approach.
Reference issue: [#179](https://github.com/TimonPost/crossterm/issues/179)