### PR TITLE
crossterm_input test/docstrings fixes

### DIFF
--- a/crossterm_input/src/input/input.rs
+++ b/crossterm_input/src/input/input.rs
@@ -44,11 +44,11 @@ impl TerminalInput {
     ///
     /// # Example
     /// ```rust
-    /// let input = input();
-    ///  match input.read_line() {
+    /// let input = crossterm_input::input();
+    /// match input.read_line() {
     ///     Ok(s) => println!("string typed: {}", s),
     ///     Err(e) => println!("error: {}", e),
-    ///  }
+    /// }
     /// ```
     pub fn read_line(&self) -> io::Result<String> {
         let mut rv = String::new();
@@ -61,12 +61,12 @@ impl TerminalInput {
     /// Read one character from the user input
     ///
     /// ```rust
-    /// let input = input();
+    /// let input = crossterm_input::input();
     ///
-    ///  match input.read_char() {
+    /// match input.read_char() {
     ///     Ok(c) => println!("character pressed: {}", c),
     ///     Err(e) => println!("error: {}", e),
-    ///   }
+    /// }
     /// ```
     pub fn read_char(&self) -> io::Result<char> {
         self.input.read_char()

--- a/crossterm_input/src/input/input.rs
+++ b/crossterm_input/src/input/input.rs
@@ -43,9 +43,8 @@ impl TerminalInput {
     /// Not sure what 'raw mode' is, checkout the 'crossterm_screen' crate.
     ///
     /// # Example
-    /// ```rust
-    /// let input = crossterm_input::input();
-    /// match input.read_line() {
+    /// ```ignore
+    /// match input().read_line() {
     ///     Ok(s) => println!("string typed: {}", s),
     ///     Err(e) => println!("error: {}", e),
     /// }
@@ -60,10 +59,8 @@ impl TerminalInput {
 
     /// Read one character from the user input
     ///
-    /// ```rust
-    /// let input = crossterm_input::input();
-    ///
-    /// match input.read_char() {
+    /// ```ignore
+    /// match input().read_char() {
     ///     Ok(c) => println!("character pressed: {}", c),
     ///     Err(e) => println!("error: {}", e),
     /// }

--- a/crossterm_input/src/input/input.rs
+++ b/crossterm_input/src/input/input.rs
@@ -44,7 +44,8 @@ impl TerminalInput {
     ///
     /// # Example
     /// ```ignore
-    /// match input().read_line() {
+    /// let in = input();
+    /// match in.read_line() {
     ///     Ok(s) => println!("string typed: {}", s),
     ///     Err(e) => println!("error: {}", e),
     /// }
@@ -60,7 +61,8 @@ impl TerminalInput {
     /// Read one character from the user input
     ///
     /// ```ignore
-    /// match input().read_char() {
+    /// let in = input();
+    /// match in.read_char() {
     ///     Ok(c) => println!("character pressed: {}", c),
     ///     Err(e) => println!("error: {}", e),
     /// }

--- a/crossterm_input/src/input/unix_input.rs
+++ b/crossterm_input/src/input/unix_input.rs
@@ -487,10 +487,10 @@ where
 #[test]
 fn test_parse_utf8() {
     let st = "abcéŷ¤£€ù%323";
-    let ref mut bytes = st.bytes().map(|x| Ok(x));
+    let ref mut bytes = st.bytes();
     let chars = st.chars();
     for c in chars {
-        let b = bytes.next().unwrap().unwrap();
+        let b = bytes.next().unwrap();
         assert_eq!(c, parse_utf8_char(b, bytes).unwrap());
     }
 }


### PR DESCRIPTION
Fixes `crossterm_input` test & doc string examples.

`cd crossterm_input && cargo test` is passing.