### PR TITLE
crossterm_style fixes

### DIFF
--- a/crossterm_style/examples/style.rs
+++ b/crossterm_style/examples/style.rs
@@ -388,6 +388,4 @@ pub fn reset_fg_and_bg() {
     println!("{}", Colored::Bg(Color::Reset));
 }
 
-fn main() {
-    command()
-}
+fn main() {}

--- a/crossterm_style/examples/style.rs
+++ b/crossterm_style/examples/style.rs
@@ -1,12 +1,7 @@
 //!
 //! Examples of coloring the terminal.
 //!
-#[macro_use]
-extern crate crossterm_style;
-
-use self::crossterm_style::{
-    color, style, Attribute, Color, Colored, Colorize, Styler, TerminalColor,
-};
+use crossterm_style::{color, Attribute, Color, Colored, Colorize, Styler};
 
 /// print some red text | demonstration.
 pub fn paint_foreground() {

--- a/crossterm_style/src/ansi_color.rs
+++ b/crossterm_style/src/ansi_color.rs
@@ -1,11 +1,11 @@
 //! This is a ANSI specific implementation for styling related action.
 //! This module is used for Windows 10 terminals and Unix terminals by default.
 
-use crate::{Attribute, Color, ITerminalColor};
-use crossterm_utils::{write_cout, Result};
-
-use crate::Colored;
 use std::io::Write;
+
+use crossterm_utils::{csi, write_cout, Result};
+
+use crate::{Attribute, Color, Colored, ITerminalColor};
 
 #[inline]
 pub fn get_set_fg_ansi(fg_color: Color) -> String {

--- a/crossterm_style/src/color.rs
+++ b/crossterm_style/src/color.rs
@@ -1,15 +1,15 @@
 //! A module that contains all the actions related to the styling of the terminal.
 //! Like applying attributes to text and changing the foreground and background.
 
+use std::clone::Clone;
 use std::io;
 
 use super::*;
 use crate::{Color, ITerminalColor};
-use crossterm_utils::{impl_display, Command, Result};
-use std::clone::Clone;
 
 #[cfg(windows)]
 use crossterm_utils::supports_ansi;
+use crossterm_utils::{impl_display, Command, Result};
 
 /// Allows you to style the terminal.
 ///

--- a/crossterm_style/src/enums/attribute.rs
+++ b/crossterm_style/src/enums/attribute.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+use crossterm_utils::csi;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/crossterm_style/src/enums/colored.rs
+++ b/crossterm_style/src/enums/colored.rs
@@ -1,9 +1,10 @@
-use crate::color::color;
-use crate::enums::Color;
 use std::fmt::Display;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+use crate::color::color;
+use crate::enums::Color;
 
 /// Could be used to color the foreground or background color.
 ///

--- a/crossterm_style/src/enums/mod.rs
+++ b/crossterm_style/src/enums/mod.rs
@@ -1,5 +1,5 @@
+pub use self::{attribute::Attribute, color::Color, colored::Colored};
+
 mod attribute;
 mod color;
 mod colored;
-
-pub use self::{attribute::Attribute, color::Color, colored::Colored};

--- a/crossterm_style/src/lib.rs
+++ b/crossterm_style/src/lib.rs
@@ -2,11 +2,6 @@
 //! Like applying attributes to text and changing the foreground and background.
 
 #[macro_use]
-extern crate crossterm_utils;
-#[cfg(windows)]
-extern crate crossterm_winapi;
-
-#[macro_use]
 mod macros;
 mod color;
 mod enums;
@@ -18,18 +13,18 @@ mod ansi_color;
 #[cfg(windows)]
 mod winapi_color;
 
+use std::fmt::Display;
+
 use self::ansi_color::AnsiColor;
 #[cfg(windows)]
 use self::winapi_color::WinApiColor;
-
-use std::fmt::Display;
+pub use crossterm_utils::{execute, queue, Command, ExecutableCommand, QueueableCommand, Result};
 
 pub use self::color::{color, PrintStyledFont, SetAttr, SetBg, SetFg, TerminalColor};
 pub use self::enums::{Attribute, Color, Colored};
 pub use self::objectstyle::ObjectStyle;
 pub use self::styledobject::StyledObject;
 pub use self::traits::{Colorize, Styler};
-pub use crossterm_utils::{execute, queue, Command, ExecutableCommand, QueueableCommand, Result};
 
 /// This trait defines the actions that can be performed with terminal colors.
 /// This trait can be implemented so that a concrete implementation of the ITerminalColor can fulfill

--- a/crossterm_style/src/objectstyle.rs
+++ b/crossterm_style/src/objectstyle.rs
@@ -1,10 +1,8 @@
 //! This module contains the `object style` that can be applied to an `styled object`.
 
-use super::{Color, StyledObject};
-
 use std::fmt::Display;
 
-use super::Attribute;
+use super::{Attribute, Color, StyledObject};
 
 /// Struct that contains the style properties that can be applied to a displayable object.
 #[derive(Debug, Clone)]

--- a/crossterm_style/src/styledobject.rs
+++ b/crossterm_style/src/styledobject.rs
@@ -1,11 +1,14 @@
 //! This module contains the logic to style an object that contains some 'content' which can be styled.
 
-use super::{color, Color, ObjectStyle, SetBg, SetFg};
 use std::fmt::{self, Display, Formatter};
 use std::result;
 
-use super::Attribute;
+use crossterm_utils::{csi, queue};
+
 use crate::{Colorize, Styler};
+
+use super::Attribute;
+use super::{color, Color, ObjectStyle, SetBg, SetFg};
 
 /// Contains both the style and the content which can be styled.
 #[derive(Clone)]

--- a/crossterm_style/src/traits.rs
+++ b/crossterm_style/src/traits.rs
@@ -1,5 +1,6 @@
-use crate::StyledObject;
 use std::fmt::Display;
+
+use crate::StyledObject;
 
 /// Provides a set of methods to color any type implementing `Display` with attributes.
 ///

--- a/crossterm_style/src/winapi_color.rs
+++ b/crossterm_style/src/winapi_color.rs
@@ -1,12 +1,14 @@
 //! This is a `WinApi` specific implementation for styling related action.
 //! This module is used for non supporting `ANSI` Windows terminals.
 
-use crate::{Color, Colored, ITerminalColor};
-use crossterm_utils::Result;
-use crossterm_winapi::{Console, Handle, HandleType, ScreenBuffer};
 use std::io;
 use std::sync::{Once, ONCE_INIT};
+
+use crossterm_utils::Result;
+use crossterm_winapi::{Console, Handle, HandleType, ScreenBuffer};
 use winapi::um::wincon;
+
+use crate::{Color, Colored, ITerminalColor};
 
 const FG_GREEN: u16 = wincon::FOREGROUND_GREEN;
 const FG_RED: u16 = wincon::FOREGROUND_RED;


### PR DESCRIPTION
* Removed unused imports
* Optimised imports (order, ...)
* As this is the 2018 edition crate, removed extern crate, etc.
* Fixed `style.rs` example by removing `command()` call (no such fn)

`cd crossterm_style && cargo test` is passing.