### PR TITLE
crossterm_screen fixes

### DIFF
--- a/crossterm_screen/examples/alternate_screen.rs
+++ b/crossterm_screen/examples/alternate_screen.rs
@@ -1,12 +1,8 @@
-extern crate crossterm_screen;
-
 use crossterm_screen::AlternateScreen;
 
-use std::io::{stdout, Write};
-use std::{thread, time};
-
 /// print wait screen on alternate screen, then switch back.
-pub fn print_wait_screen_on_alternate_window() {
+#[allow(unused_variables)]
+fn main() {
     // move to the alternate screen, 'false' determines if the alternate screen should be in raw mode.
     if let Ok(alternate) = AlternateScreen::to_alternate(false) {
         // do some stuff on the alternate screen.

--- a/crossterm_screen/examples/raw_mode.rs
+++ b/crossterm_screen/examples/raw_mode.rs
@@ -1,11 +1,9 @@
-extern crate crossterm_screen;
+use std::io::stdout;
 
 use crossterm_screen::{IntoRawMode, RawScreen};
 
-use std::io::{stdout, Write};
-use std::{thread, time};
-
-pub fn raw_modes() {
+#[allow(unused_variables)]
+fn main() {
     // create a Screen instance that operates on the default output: io::stdout(). By passing in 'true', we make this screen 'raw'
     let screen = RawScreen::into_raw_mode();
     let screen = stdout().into_raw_mode();

--- a/crossterm_screen/src/lib.rs
+++ b/crossterm_screen/src/lib.rs
@@ -1,15 +1,6 @@
 //! A module which provides some functionalities to work with the terminal screen.
 //! Like allowing you to switch between the main and alternate screen or putting the terminal into raw mode.
-#[macro_use]
-extern crate crossterm_utils;
-
-#[cfg(windows)]
-extern crate winapi;
-
-#[cfg(windows)]
-extern crate crossterm_winapi;
+pub use self::screen::{AlternateScreen, IntoRawMode, RawScreen};
 
 mod screen;
 mod sys;
-
-pub use self::screen::{AlternateScreen, IntoRawMode, RawScreen};

--- a/crossterm_screen/src/screen/alternate.rs
+++ b/crossterm_screen/src/screen/alternate.rs
@@ -5,15 +5,16 @@
 //! For an example of this behavior, consider when vim is launched from bash.
 //! Vim uses the entirety of the screen to edit the file, then returning to bash leaves the original buffer unchanged.
 
-#[cfg(windows)]
-use crate::sys::winapi::ToAlternateScreenCommand;
+use std::io;
+
 #[cfg(windows)]
 use crossterm_utils::supports_ansi;
 
+#[cfg(windows)]
+use crate::sys::winapi::ToAlternateScreenCommand;
 use crate::sys::{self, IAlternateScreenCommand};
 
 use super::RawScreen;
-use std::io;
 
 /// With this type you will be able to switch to the alternate screen and then back to the main screen.
 /// Check also the Screen type for switching to alternate mode.

--- a/crossterm_screen/src/screen/raw.rs
+++ b/crossterm_screen/src/screen/raw.rs
@@ -14,8 +14,9 @@
 //!
 //! With these modes you can easier design the terminal screen.
 
-use crate::sys;
 use std::io::{self, Stdout, Write};
+
+use crate::sys;
 
 /// A wrapper for the raw terminal state, which can be used to write to.
 ///

--- a/crossterm_screen/src/sys/mod.rs
+++ b/crossterm_screen/src/sys/mod.rs
@@ -1,11 +1,12 @@
+use std::io::Write;
+
+use crossterm_utils::{csi, write_cout, Result};
+
 #[cfg(unix)]
 pub mod unix;
 
 #[cfg(windows)]
 pub mod winapi;
-
-use crossterm_utils::Result;
-use std::io::Write;
 
 /// This command is used for switching to the alternate screen and back to the main screen.
 pub struct ToAlternateScreenCommand;

--- a/crossterm_screen/src/sys/winapi.rs
+++ b/crossterm_screen/src/sys/winapi.rs
@@ -1,9 +1,14 @@
-use super::IAlternateScreenCommand;
-use crossterm_utils::Result;
-use crossterm_winapi::{ConsoleMode, Handle, ScreenBuffer};
 use std::io;
+
 use winapi::shared::minwindef::DWORD;
 use winapi::um::wincon;
+
+use crossterm_utils::Result;
+use crossterm_winapi::{ConsoleMode, Handle, ScreenBuffer};
+
+use super::IAlternateScreenCommand;
+
+use self::wincon::{ENABLE_LINE_INPUT, ENABLE_WRAP_AT_EOL_OUTPUT};
 
 /// This command is used for enabling and disabling raw mode for Windows systems.
 /// For more info check: https://docs.microsoft.com/en-us/windows/console/high-level-console-modes.
@@ -11,7 +16,7 @@ use winapi::um::wincon;
 pub struct RawModeCommand {
     mask: DWORD,
 }
-use self::wincon::{ENABLE_LINE_INPUT, ENABLE_WRAP_AT_EOL_OUTPUT};
+
 impl RawModeCommand {
     pub fn new() -> Self {
         RawModeCommand {


### PR DESCRIPTION
* Fixed examples
* Optimised imports
* Removed extern crate (2018 edition)

`cd crossterm_screen && cargo test` is passing.