### PR TITLE
crossterm_terminal fixes

### DIFF
--- a/crossterm_terminal/examples/terminal.rs
+++ b/crossterm_terminal/examples/terminal.rs
@@ -1,8 +1,7 @@
 //!
 //! Terminal Examples
 //!
-extern crate crossterm_cursor;
-extern crate crossterm_terminal;
+#![allow(unused_must_use)]
 
 use crossterm_cursor::cursor;
 use crossterm_terminal::{terminal, ClearType};

--- a/crossterm_terminal/src/lib.rs
+++ b/crossterm_terminal/src/lib.rs
@@ -1,13 +1,3 @@
-#[macro_use]
-extern crate crossterm_utils;
-extern crate crossterm_cursor;
-
-#[cfg(windows)]
-extern crate crossterm_winapi;
-
-#[cfg(unix)]
-extern crate libc;
-
 mod sys;
 mod terminal;
 

--- a/crossterm_terminal/src/sys/mod.rs
+++ b/crossterm_terminal/src/sys/mod.rs
@@ -1,10 +1,10 @@
+#[cfg(unix)]
+pub use self::unix::{exit, get_terminal_size};
+#[cfg(windows)]
+pub use self::winapi::{exit, get_terminal_size};
+
 #[cfg(windows)]
 pub mod winapi;
 
 #[cfg(unix)]
 pub mod unix;
-
-#[cfg(unix)]
-pub use self::unix::{exit, get_terminal_size};
-#[cfg(windows)]
-pub use self::winapi::{exit, get_terminal_size};

--- a/crossterm_terminal/src/terminal/ansi_terminal.rs
+++ b/crossterm_terminal/src/terminal/ansi_terminal.rs
@@ -1,11 +1,14 @@
 //! This is an `ANSI escape code` specific implementation for terminal related action.
 //! This module is used for windows 10 terminals and unix terminals by default.
 
-use super::ITerminal;
-use crate::{sys::get_terminal_size, ClearType};
-use crossterm_cursor::TerminalCursor;
-use crossterm_utils::Result;
 use std::io::Write;
+
+use crossterm_cursor::TerminalCursor;
+use crossterm_utils::{csi, write_cout, Result};
+
+use crate::{sys::get_terminal_size, ClearType};
+
+use super::ITerminal;
 
 pub static CLEAR_ALL: &'static str = csi!("2J");
 pub static CLEAR_FROM_CURSOR_DOWN: &'static str = csi!("J");

--- a/crossterm_terminal/src/terminal/mod.rs
+++ b/crossterm_terminal/src/terminal/mod.rs
@@ -1,4 +1,14 @@
 //! A module that contains all the actions related to the terminal. like clearing, resizing, pausing and scrolling the terminal.
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crossterm_utils::Result;
+
+use self::ansi_terminal::AnsiTerminal;
+pub use self::terminal::{terminal, Clear, ScrollDown, ScrollUp, SetSize, Terminal};
+#[cfg(windows)]
+use self::winapi_terminal::WinApiTerminal;
+
 #[cfg(test)]
 mod test;
 
@@ -7,17 +17,6 @@ mod terminal;
 mod ansi_terminal;
 #[cfg(windows)]
 mod winapi_terminal;
-
-use self::ansi_terminal::AnsiTerminal;
-#[cfg(windows)]
-use self::winapi_terminal::WinApiTerminal;
-
-pub use self::terminal::{terminal, Clear, ScrollDown, ScrollUp, SetSize, Terminal};
-
-use crossterm_utils::Result;
-
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
 
 /// Enum with the different values to clear the terminal.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/crossterm_terminal/src/terminal/terminal.rs
+++ b/crossterm_terminal/src/terminal/terminal.rs
@@ -1,16 +1,16 @@
 //! A module that contains all the actions related to the terminal.
 //! Like clearing and scrolling in the terminal or getting the window size from the terminal.
 
-use super::{AnsiTerminal, ClearType, ITerminal};
-use crossterm_utils::{Command, Result};
+use std::fmt;
+use std::io::Write;
+
+#[cfg(windows)]
+use crossterm_utils::supports_ansi;
+use crossterm_utils::{impl_display, write_cout, Command, Result};
 
 #[cfg(windows)]
 use super::WinApiTerminal;
-#[cfg(windows)]
-use crossterm_utils::supports_ansi;
-
-use std::fmt;
-use std::io::Write;
+use super::{AnsiTerminal, ClearType, ITerminal};
 
 /// Allows you to preform actions on the terminal.
 ///

--- a/crossterm_terminal/src/terminal/winapi_terminal.rs
+++ b/crossterm_terminal/src/terminal/winapi_terminal.rs
@@ -3,11 +3,13 @@
 //!
 //! Windows versions lower then windows 10 are not supporting ANSI codes. Those versions will use this implementation instead.
 
-use super::*;
-use crate::sys::winapi::get_terminal_size;
 use crossterm_cursor::sys::winapi::Cursor;
 use crossterm_utils::{ErrorKind, Result};
 use crossterm_winapi::{Console, Coord, Handle, ScreenBuffer, Size};
+
+use crate::sys::winapi::get_terminal_size;
+
+use super::*;
 
 /// This struct is a winapi implementation for terminal related actions.
 pub struct WinApiTerminal;


### PR DESCRIPTION
* Optimised imports
* Removed extern crate, ... (2018 edition)

`cd crossterm_terminal && cargo test` is passing.