### PR TITLE
io::Result cleanup

### DIFF
--- a/crossterm_cursor/src/sys/unix.rs
+++ b/crossterm_cursor/src/sys/unix.rs
@@ -25,14 +25,14 @@ pub fn show_cursor(show_cursor: bool) -> Result<()> {
     Ok(())
 }
 
-pub fn pos() -> io::Result<(u16, u16)> {
+pub fn pos() -> Result<(u16, u16)> {
     unix::into_raw_mode()?;
     let pos = pos_raw();
     unix::disable_raw_mode()?;
     pos
 }
 
-pub fn pos_raw() -> io::Result<(u16, u16)> {
+pub fn pos_raw() -> Result<(u16, u16)> {
     // Where is the cursor?
     // Use `ESC [ 6 n`.
     let mut stdout = io::stdout();

--- a/crossterm_input/src/input.rs
+++ b/crossterm_input/src/input.rs
@@ -1,8 +1,6 @@
 //! A module that contains all the actions related to reading input from the terminal.
 //! Like reading a line, reading a character and reading asynchronously.
 
-use std::io;
-
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -31,7 +29,7 @@ mod windows_input;
 /// Unix is using the 'TTY' and windows is using 'libc' C functions to read the input.
 trait ITerminalInput {
     /// Read one character from the user input
-    fn read_char(&self) -> io::Result<char>;
+    fn read_char(&self) -> Result<char>;
     /// Read the input asynchronously from the user.
     fn read_async(&self) -> AsyncReader;
     ///  Read the input asynchronously until a certain character is hit.

--- a/crossterm_input/src/input/input.rs
+++ b/crossterm_input/src/input/input.rs
@@ -57,7 +57,7 @@ impl TerminalInput {
     ///     Err(e) => println!("error: {}", e),
     /// }
     /// ```
-    pub fn read_line(&self) -> io::Result<String> {
+    pub fn read_line(&self) -> Result<String> {
         let mut rv = String::new();
         io::stdin().read_line(&mut rv)?;
         let len = rv.trim_end_matches(&['\r', '\n'][..]).len();
@@ -74,7 +74,7 @@ impl TerminalInput {
     ///     Err(e) => println!("error: {}", e),
     /// }
     /// ```
-    pub fn read_char(&self) -> io::Result<char> {
+    pub fn read_char(&self) -> Result<char> {
         self.input.read_char()
     }
 

--- a/crossterm_input/src/input/unix_input.rs
+++ b/crossterm_input/src/input/unix_input.rs
@@ -26,7 +26,7 @@ impl UnixInput {
 }
 
 impl ITerminalInput for UnixInput {
-    fn read_char(&self) -> io::Result<char> {
+    fn read_char(&self) -> Result<char> {
         read_char_raw()
     }
 

--- a/crossterm_input/src/input/windows_input.rs
+++ b/crossterm_input/src/input/windows_input.rs
@@ -42,7 +42,7 @@ const ENABLE_MOUSE_MODE: u32 = 0x0010 | 0x0080 | 0x0008;
 static mut ORIG_MODE: u32 = 0;
 
 impl ITerminalInput for WindowsInput {
-    fn read_char(&self) -> io::Result<char> {
+    fn read_char(&self) -> Result<char> {
         // _getwch is without echo and _getwche is with echo
         let pressed_char = unsafe { _getwche() };
 

--- a/crossterm_input/src/input/windows_input.rs
+++ b/crossterm_input/src/input/windows_input.rs
@@ -48,21 +48,16 @@ impl ITerminalInput for WindowsInput {
 
         // we could return error but maybe option to keep listening until valid character is inputted.
         if pressed_char == 0 || pressed_char == 0xe0 {
-            return Err(io::Error::new(
+            Err(io::Error::new(
                 io::ErrorKind::Other,
                 "Given input char is not a valid char, mostly occurs when pressing special keys",
-            ));
+            ))?;
         }
 
-        match char::from_u32(pressed_char as u32) {
-            Some(c) => {
-                return Ok(c);
-            }
-            None => Err(io::Error::new(
-                io::ErrorKind::Other,
-                "Could not parse given input to char",
-            )),
-        }
+        char::from_u32(pressed_char as u32).ok_or_else(io::Error::new(
+            io::ErrorKind::Other,
+            "Could not parse given input to char",
+        ))
     }
 
     fn read_async(&self) -> AsyncReader {

--- a/crossterm_input/src/input/windows_input.rs
+++ b/crossterm_input/src/input/windows_input.rs
@@ -54,10 +54,11 @@ impl ITerminalInput for WindowsInput {
             ))?;
         }
 
-        char::from_u32(pressed_char as u32).ok_or_else(io::Error::new(
-            io::ErrorKind::Other,
-            "Could not parse given input to char",
-        ))
+        let ch = char::from_u32(pressed_char as u32).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::Other, "Could not parse given input to char")
+        })?;
+
+        Ok(ch)
     }
 
     fn read_async(&self) -> AsyncReader {

--- a/crossterm_input/src/sys/unix.rs
+++ b/crossterm_input/src/sys/unix.rs
@@ -1,17 +1,21 @@
 use std::os::unix::io::AsRawFd;
 use std::{fs, io};
 
+use crossterm_utils::Result;
+
 /// Get the TTY device.
 ///
 /// This allows for getting stdio representing _only_ the TTY, and not other streams.
-pub fn get_tty() -> io::Result<fs::File> {
-    fs::OpenOptions::new()
+pub fn get_tty() -> Result<fs::File> {
+    let file = fs::OpenOptions::new()
         .read(true)
         .write(true)
-        .open("/dev/tty")
+        .open("/dev/tty")?;
+
+    Ok(file)
 }
 
-fn get_tty_fd() -> io::Result<i32> {
+fn get_tty_fd() -> Result<i32> {
     let fd = unsafe {
         if libc::isatty(libc::STDIN_FILENO) == 1 {
             libc::STDIN_FILENO
@@ -23,7 +27,7 @@ fn get_tty_fd() -> io::Result<i32> {
     Ok(fd)
 }
 
-pub fn read_char_raw() -> io::Result<char> {
+pub fn read_char_raw() -> Result<char> {
     let mut buf = [0u8; 20];
 
     let fd = get_tty_fd()?;
@@ -50,7 +54,7 @@ pub fn read_char_raw() -> io::Result<char> {
 
             pressed_char
         }
-    };
+    }?;
 
-    rv
+    Ok(rv)
 }

--- a/crossterm_screen/src/screen/alternate.rs
+++ b/crossterm_screen/src/screen/alternate.rs
@@ -5,10 +5,9 @@
 //! For an example of this behavior, consider when vim is launched from bash.
 //! Vim uses the entirety of the screen to edit the file, then returning to bash leaves the original buffer unchanged.
 
-use std::io;
-
 #[cfg(windows)]
 use crossterm_utils::supports_ansi;
+use crossterm_utils::Result;
 
 #[cfg(windows)]
 use crate::sys::winapi::ToAlternateScreenCommand;
@@ -38,7 +37,7 @@ impl AlternateScreen {
     /// The alternate buffer dimensions are exactly the same as the window, without any scrollback region.
     /// For an example of this behavior, consider when vim is launched from bash.
     /// Vim uses the entirety of the screen to edit the file, then returning to bash leaves the original buffer unchanged.
-    pub fn to_alternate(raw_mode: bool) -> io::Result<AlternateScreen> {
+    pub fn to_alternate(raw_mode: bool) -> Result<AlternateScreen> {
         #[cfg(windows)]
         let command = if supports_ansi() {
             Box::from(sys::ToAlternateScreenCommand::new())
@@ -68,9 +67,8 @@ impl AlternateScreen {
     }
 
     /// Switch the alternate screen back to the main screen.
-    pub fn to_main(&self) -> io::Result<()> {
-        self.command.disable()?;
-        Ok(())
+    pub fn to_main(&self) -> Result<()> {
+        self.command.disable()
     }
 }
 

--- a/crossterm_screen/src/screen/raw.rs
+++ b/crossterm_screen/src/screen/raw.rs
@@ -14,7 +14,9 @@
 //!
 //! With these modes you can easier design the terminal screen.
 
-use std::io::{self, Stdout, Write};
+use std::io::{Stdout, Write};
+
+use crossterm_utils::Result;
 
 use crate::sys;
 
@@ -27,7 +29,7 @@ pub struct RawScreen {
 
 impl RawScreen {
     /// Put terminal in raw mode.
-    pub fn into_raw_mode() -> io::Result<RawScreen> {
+    pub fn into_raw_mode() -> Result<RawScreen> {
         #[cfg(unix)]
         let mut command = sys::unix::RawModeCommand::new();
         #[cfg(windows)]
@@ -39,7 +41,7 @@ impl RawScreen {
     }
 
     /// Put terminal back in original modes.
-    pub fn disable_raw_mode() -> io::Result<()> {
+    pub fn disable_raw_mode() -> Result<()> {
         #[cfg(unix)]
         let mut command = sys::unix::RawModeCommand::new();
         #[cfg(windows)]
@@ -67,11 +69,11 @@ pub trait IntoRawMode: Write + Sized {
     /// Raw mode means that stdin won't be printed (it will instead have to be written manually by
     /// the program). Furthermore, the input isn't canonicalised or buffered (that is, you can
     /// read from stdin one byte of a time). The output is neither modified in any way.
-    fn into_raw_mode(self) -> io::Result<RawScreen>;
+    fn into_raw_mode(self) -> Result<RawScreen>;
 }
 
 impl IntoRawMode for Stdout {
-    fn into_raw_mode(self) -> io::Result<RawScreen> {
+    fn into_raw_mode(self) -> Result<RawScreen> {
         RawScreen::into_raw_mode()?;
         // this make's sure that raw screen will be disabled when it goes out of scope.
         Ok(RawScreen { drop: true })

--- a/crossterm_screen/src/sys/unix.rs
+++ b/crossterm_screen/src/sys/unix.rs
@@ -1,4 +1,4 @@
-use std::io::Result;
+use crossterm_utils::Result;
 
 /// This command is used for enabling and disabling raw mode for the terminal.
 pub struct RawModeCommand;

--- a/crossterm_screen/src/sys/winapi.rs
+++ b/crossterm_screen/src/sys/winapi.rs
@@ -1,5 +1,3 @@
-use std::io;
-
 use winapi::shared::minwindef::DWORD;
 use winapi::um::wincon;
 

--- a/crossterm_screen/src/sys/winapi.rs
+++ b/crossterm_screen/src/sys/winapi.rs
@@ -27,7 +27,7 @@ impl RawModeCommand {
 
 impl RawModeCommand {
     /// Enables raw mode.
-    pub fn enable(&mut self) -> io::Result<()> {
+    pub fn enable(&mut self) -> Result<()> {
         let console_mode = ConsoleMode::new()?;
 
         let dw_mode = console_mode.mode()?;
@@ -40,7 +40,7 @@ impl RawModeCommand {
     }
 
     /// Disables raw mode.
-    pub fn disable(&self) -> io::Result<()> {
+    pub fn disable(&self) -> Result<()> {
         let console_mode = ConsoleMode::new()?;
 
         let dw_mode = console_mode.mode()?;

--- a/crossterm_style/src/color.rs
+++ b/crossterm_style/src/color.rs
@@ -3,7 +3,6 @@
 
 use std::clone::Clone;
 use std::fmt::Display;
-use std::io;
 
 #[cfg(windows)]
 use crossterm_utils::supports_ansi;
@@ -67,7 +66,7 @@ impl TerminalColor {
 
     /// Get available color count.
     /// (This does not always provide a good result.)
-    pub fn get_available_color_count(&self) -> io::Result<u16> {
+    pub fn get_available_color_count(&self) -> Result<u16> {
         use std::env;
         Ok(match env::var_os("TERM") {
             Some(val) => {

--- a/crossterm_style/src/winapi_color.rs
+++ b/crossterm_style/src/winapi_color.rs
@@ -173,7 +173,7 @@ fn color_value(color: Colored) -> String {
     winapi_color.to_string()
 }
 
-fn init_console_color() -> io::Result<()> {
+fn init_console_color() -> Result<()> {
     let screen_buffer = ScreenBuffer::current()?;
 
     let attr = screen_buffer.info()?.attributes();

--- a/crossterm_style/src/winapi_color.rs
+++ b/crossterm_style/src/winapi_color.rs
@@ -1,7 +1,6 @@
 //! This is a `WinApi` specific implementation for styling related action.
 //! This module is used for non supporting `ANSI` Windows terminals.
 
-use std::io;
 use std::sync::Once;
 
 use winapi::um::wincon;

--- a/crossterm_utils/src/command.rs
+++ b/crossterm_utils/src/command.rs
@@ -1,8 +1,7 @@
 use std::fmt::Display;
 use std::io::Write;
 
-use crate::Result;
-use crate::{execute, impl_display, queue, write_cout};
+use crate::{execute, impl_display, queue, write_cout, Result};
 
 /// A command is an action that can be performed on the terminal.
 ///

--- a/crossterm_utils/src/error.rs
+++ b/crossterm_utils/src/error.rs
@@ -49,18 +49,3 @@ impl From<fmt::Error> for ErrorKind {
         ErrorKind::FmtError(e)
     }
 }
-
-//impl From<std::result::::Error> for ErrorKind {
-//    fn from(e: fmt::Error) -> ErrorKind {
-//        ErrorKind::FmtError(e)
-//    }
-//}
-
-impl From<ErrorKind> for io::Error {
-    fn from(e: ErrorKind) -> io::Error {
-        match e {
-            ErrorKind::IoError(io) => return io,
-            _ => io::Error::new(io::ErrorKind::Other, "can not convert error to IO error"),
-        }
-    }
-}

--- a/crossterm_utils/src/sys/winapi.rs
+++ b/crossterm_utils/src/sys/winapi.rs
@@ -1,8 +1,7 @@
 pub mod ansi {
-    use std::io;
-
     use winapi::um::wincon::ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 
+    use crossterm_utils::Result;
     use crossterm_winapi::ConsoleMode;
 
     /// Toggle virtual terminal processing.
@@ -14,7 +13,7 @@ pub mod ansi {
     /// When virtual terminal processing is enabled, characters emitted to the
     /// console are parsed for VT100 and similar control character sequences
     /// that control color and other similar operations.
-    pub fn set_virtual_terminal_processing(yes: bool) -> io::Result<()> {
+    pub fn set_virtual_terminal_processing(yes: bool) -> Result<()> {
         let mask = ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 
         let console_mode = ConsoleMode::new()?;

--- a/crossterm_utils/src/sys/winapi.rs
+++ b/crossterm_utils/src/sys/winapi.rs
@@ -1,7 +1,7 @@
 pub mod ansi {
     use winapi::um::wincon::ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 
-    use crossterm_utils::Result;
+    use crate::Result;
     use crossterm_winapi::ConsoleMode;
 
     /// Toggle virtual terminal processing.

--- a/examples/alternate_screen.rs
+++ b/examples/alternate_screen.rs
@@ -34,8 +34,9 @@ fn print_wait_screen() -> Result<()> {
 }
 
 /// print wait screen on alternate screen, then switch back.
-pub fn print_wait_screen_on_alternate_window() -> Result<()> {
-    AlternateScreen::to_alternate(false).and_then(|_| print_wait_screen())
+fn print_wait_screen_on_alternate_window() -> Result<()> {
+    let _alt = AlternateScreen::to_alternate(false)?;
+    print_wait_screen()
 }
 
 // cargo run --example alternate_screen

--- a/examples/alternate_screen.rs
+++ b/examples/alternate_screen.rs
@@ -1,8 +1,8 @@
-use std::{io, thread, time};
+use std::{thread, time};
 
-use crossterm::{style, AlternateScreen, ClearType, Color, Crossterm};
+use crossterm::{style, AlternateScreen, ClearType, Color, Crossterm, Result};
 
-fn print_wait_screen() -> io::Result<()> {
+fn print_wait_screen() -> Result<()> {
     let crossterm = Crossterm::new();
     let terminal = crossterm.terminal();
     let cursor = crossterm.cursor();
@@ -34,15 +34,11 @@ fn print_wait_screen() -> io::Result<()> {
 }
 
 /// print wait screen on alternate screen, then switch back.
-pub fn print_wait_screen_on_alternate_window() -> io::Result<()> {
-    if let Ok(_alternate) = AlternateScreen::to_alternate(false) {
-        print_wait_screen()?;
-    }
-
-    Ok(())
+pub fn print_wait_screen_on_alternate_window() -> Result<()> {
+    AlternateScreen::to_alternate(false).and_then(|_| print_wait_screen())
 }
 
 // cargo run --example alternate_screen
-fn main() {
-    print_wait_screen_on_alternate_window().unwrap();
+fn main() -> Result<()> {
+    print_wait_screen_on_alternate_window()
 }

--- a/examples/command.rs
+++ b/examples/command.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::io::{stdout, Write};
 
 use crossterm::{
@@ -5,7 +7,7 @@ use crossterm::{
 };
 
 /// execute commands by using normal functions
-pub fn execute_command_directly_using_functions() -> Result<()> {
+fn execute_command_directly_using_functions() -> Result<()> {
     // single command
     stdout().execute(Output("Text1 ".to_string()))?;
 
@@ -18,7 +20,7 @@ pub fn execute_command_directly_using_functions() -> Result<()> {
 }
 
 /// execute commands by using macro's
-pub fn execute_command_directly_using_macros() -> Result<()> {
+fn execute_command_directly_using_macros() -> Result<()> {
     // single command
     execute!(stdout(), Output("Text1 ".to_string()))?;
 
@@ -31,7 +33,7 @@ pub fn execute_command_directly_using_macros() -> Result<()> {
 }
 
 /// queue commands without executing them directly by using normal functions
-pub fn later_execution_command_using_functions() -> Result<()> {
+fn later_execution_command_using_functions() -> Result<()> {
     let mut sdout = stdout();
 
     // single command
@@ -54,7 +56,7 @@ pub fn later_execution_command_using_functions() -> Result<()> {
 }
 
 /// queue commands without executing them directly by using macro's
-pub fn later_execution_command_directly_using_macros() -> Result<()> {
+fn later_execution_command_directly_using_macros() -> Result<()> {
     let mut stdout = stdout();
 
     // single command

--- a/examples/command.rs
+++ b/examples/command.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::io::{stdout, Write};
 
 use crossterm::{
@@ -7,7 +5,7 @@ use crossterm::{
 };
 
 /// execute commands by using normal functions
-fn execute_command_directly_using_functions() -> Result<()> {
+pub fn execute_command_directly_using_functions() -> Result<()> {
     // single command
     stdout().execute(Output("Text1 ".to_string()))?;
 
@@ -20,7 +18,7 @@ fn execute_command_directly_using_functions() -> Result<()> {
 }
 
 /// execute commands by using macro's
-fn execute_command_directly_using_macros() -> Result<()> {
+pub fn execute_command_directly_using_macros() -> Result<()> {
     // single command
     execute!(stdout(), Output("Text1 ".to_string()))?;
 
@@ -29,13 +27,11 @@ fn execute_command_directly_using_macros() -> Result<()> {
         stdout(),
         Output("Text2 ".to_string()),
         Output("Text 3".to_string())
-    )?;
-
-    Ok(())
+    )
 }
 
 /// queue commands without executing them directly by using normal functions
-fn later_execution_command_using_functions() -> Result<()> {
+pub fn later_execution_command_using_functions() -> Result<()> {
     let mut sdout = stdout();
 
     // single command
@@ -58,7 +54,7 @@ fn later_execution_command_using_functions() -> Result<()> {
 }
 
 /// queue commands without executing them directly by using macro's
-fn later_execution_command_directly_using_macros() -> Result<()> {
+pub fn later_execution_command_directly_using_macros() -> Result<()> {
     let mut stdout = stdout();
 
     // single command
@@ -81,4 +77,9 @@ fn later_execution_command_directly_using_macros() -> Result<()> {
 }
 
 // cargo run --example command
-fn main() {}
+fn main() -> Result<()> {
+    later_execution_command_directly_using_macros()
+    //    later_execution_command_using_functions()
+    //    execute_command_directly_using_macros()
+    //    execute_command_directly_using_functions()
+}

--- a/examples/command_bar.rs
+++ b/examples/command_bar.rs
@@ -2,14 +2,61 @@ use std::sync::{Arc, Mutex};
 use std::{thread, time};
 
 use crossterm::{
-    cursor, input, terminal, ClearType, Crossterm, InputEvent, KeyEvent, RawScreen, Terminal,
-    TerminalCursor,
+    cursor, input, terminal, ClearType, Crossterm, InputEvent, KeyEvent, RawScreen, Result,
+    Terminal, TerminalCursor,
 };
 
+fn log(input_buf: Arc<Mutex<String>>) -> Vec<thread::JoinHandle<()>> {
+    let mut threads = Vec::with_capacity(10);
+
+    let (_, term_height) = terminal().terminal_size();
+
+    for i in 0..1 {
+        let input_buffer = input_buf.clone();
+
+        let crossterm = Crossterm::new();
+
+        let join = thread::spawn(move || {
+            let cursor = crossterm.cursor();
+            let terminal = crossterm.terminal();
+
+            for j in 0..1000 {
+                if let Err(_) = swap_write(
+                    format!("Some output: {} from thread: {}", j, i).as_ref(),
+                    &input_buffer.lock().unwrap(),
+                    &terminal,
+                    &cursor,
+                    term_height,
+                ) {
+                    return;
+                }
+                thread::sleep(time::Duration::from_millis(100));
+            }
+        });
+
+        threads.push(join);
+    }
+
+    threads
+}
+
+fn swap_write(
+    msg: &str,
+    input_buf: &String,
+    terminal: &Terminal,
+    cursor: &TerminalCursor,
+    term_height: u16,
+) -> Result<()> {
+    cursor.goto(0, term_height)?;
+    terminal.clear(ClearType::CurrentLine)?;
+    terminal.write(format!("{}\r\n", msg))?;
+    terminal.write(format!("> {}", input_buf)).map(|_| ())
+}
+
 // cargo run --example command_bar
-fn main() {
+fn main() -> Result<()> {
     let _screen = RawScreen::into_raw_mode();
-    cursor().hide().expect("Couldn't hide cursor");
+    cursor().hide()?;
 
     let input_buf = Arc::new(Mutex::new(String::new()));
 
@@ -43,56 +90,5 @@ fn main() {
         thread.join().expect("Couldn't join");
     }
 
-    cursor().show().expect("Couldn't show cursor");
-}
-
-fn log(input_buf: Arc<Mutex<String>>) -> Vec<thread::JoinHandle<()>> {
-    let mut threads = Vec::with_capacity(10);
-
-    let (_, term_height) = terminal().terminal_size();
-
-    for i in 0..1 {
-        let input_buffer = input_buf.clone();
-
-        let crossterm = Crossterm::new();
-
-        let join = thread::spawn(move || {
-            let cursor = crossterm.cursor();
-            let terminal = crossterm.terminal();
-
-            for j in 0..1000 {
-                swap_write(
-                    format!("Some output: {} from thread: {}", j, i).as_ref(),
-                    &input_buffer.lock().unwrap(),
-                    &terminal,
-                    &cursor,
-                    term_height,
-                );
-                thread::sleep(time::Duration::from_millis(100));
-            }
-        });
-
-        threads.push(join);
-    }
-
-    return threads;
-}
-
-pub fn swap_write(
-    msg: &str,
-    input_buf: &String,
-    terminal: &Terminal,
-    cursor: &TerminalCursor,
-    term_height: u16,
-) {
-    cursor.goto(0, term_height).expect("Couldn't goto");
-    terminal
-        .clear(ClearType::CurrentLine)
-        .expect("Couldn't clear current line");
-    terminal
-        .write(format!("{}\r\n", msg))
-        .expect("Couldn't write message");
-    terminal
-        .write(format!("> {}", input_buf))
-        .expect("Couldn't write prompt");
+    cursor().show()
 }

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -2,12 +2,10 @@
 //! Examples of actions that could be performed with the cursor.
 //!
 
-use std::io;
-
-use crossterm_cursor::cursor;
+use crossterm::{cursor, Result};
 
 /// Set the cursor to position X: 10, Y: 5 in the terminal.
-pub fn goto() -> io::Result<()> {
+pub fn goto() -> Result<()> {
     // Get the cursor
     let cursor = cursor();
     // Set the cursor to position X: 10, Y: 5 in the terminal
@@ -50,7 +48,7 @@ pub fn move_down() {
 }
 
 /// Save and reset cursor position | demonstration..
-pub fn save_and_reset_position() -> io::Result<()> {
+pub fn save_and_reset_position() -> Result<()> {
     let cursor = cursor();
 
     // Goto X: 5 Y: 5
@@ -72,25 +70,30 @@ pub fn save_and_reset_position() -> io::Result<()> {
 }
 
 /// Hide cursor display | demonstration.
-pub fn hide_cursor() {
+pub fn hide_cursor() -> Result<()> {
     let cursor = cursor();
-    cursor.hide().unwrap();
+    cursor.hide()
 }
 
 /// Show cursor display | demonstration.
-pub fn show_cursor() {
+pub fn show_cursor() -> Result<()> {
     let cursor = cursor();
-    cursor.show().unwrap();
+    cursor.show()
 }
 
 /// Show cursor display, only works on certain terminals.| demonstration
-pub fn blink_cursor() {
+pub fn blink_cursor(enable: bool) -> Result<()> {
     let cursor = cursor();
-    cursor.blink(false).unwrap();
-    cursor.blink(false).unwrap();
+    cursor.blink(enable)
 }
 
 // cargo run --example cursor
-fn main() {
-    hide_cursor()
+fn main() -> Result<()> {
+    println!("Going to show cursor...");
+    show_cursor()?;
+    println!("Going to enable blinking cursor & sleep for 5s...");
+    blink_cursor(true)?;
+    std::thread::sleep(std::time::Duration::from_secs(5));
+    println!("Going to disable blinking cursor...");
+    blink_cursor(false)
 }

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -2,10 +2,12 @@
 //! Examples of actions that could be performed with the cursor.
 //!
 
+#![allow(dead_code)]
+
 use crossterm::{cursor, Result};
 
 /// Set the cursor to position X: 10, Y: 5 in the terminal.
-pub fn goto() -> Result<()> {
+fn goto() -> Result<()> {
     // Get the cursor
     let cursor = cursor();
     // Set the cursor to position X: 10, Y: 5 in the terminal
@@ -15,7 +17,7 @@ pub fn goto() -> Result<()> {
 }
 
 /// get the cursor position
-pub fn pos() {
+fn pos() {
     // Get the cursor
     let cursor = cursor();
     // get the cursor position.
@@ -25,7 +27,7 @@ pub fn pos() {
 }
 
 /// Move the cursor 3 up | demonstration.
-pub fn move_up() {
+fn move_up() {
     // Get the cursor
     let mut cursor = cursor();
 
@@ -34,21 +36,21 @@ pub fn move_up() {
 }
 
 /// Move the cursor 3 to the right | demonstration.
-pub fn move_right() {
+fn move_right() {
     let mut cursor = cursor();
     // Move the cursor to position 3 times to the right in the terminal
     cursor.move_right(3);
 }
 
 /// Move the cursor 3 down | demonstration.
-pub fn move_down() {
+fn move_down() {
     let mut cursor = cursor();
     // Move the cursor to position 3 times to the down in the terminal
     cursor.move_down(3);
 }
 
 /// Save and reset cursor position | demonstration..
-pub fn save_and_reset_position() -> Result<()> {
+fn save_and_reset_position() -> Result<()> {
     let cursor = cursor();
 
     // Goto X: 5 Y: 5
@@ -70,19 +72,19 @@ pub fn save_and_reset_position() -> Result<()> {
 }
 
 /// Hide cursor display | demonstration.
-pub fn hide_cursor() -> Result<()> {
+fn hide_cursor() -> Result<()> {
     let cursor = cursor();
     cursor.hide()
 }
 
 /// Show cursor display | demonstration.
-pub fn show_cursor() -> Result<()> {
+fn show_cursor() -> Result<()> {
     let cursor = cursor();
     cursor.show()
 }
 
 /// Show cursor display, only works on certain terminals.| demonstration
-pub fn blink_cursor(enable: bool) -> Result<()> {
+fn blink_cursor(enable: bool) -> Result<()> {
     let cursor = cursor();
     cursor.blink(enable)
 }

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,6 +1,6 @@
 use crossterm::input;
 
-pub fn read_char() {
+fn read_char() {
     let input = input();
 
     match input.read_char() {
@@ -9,7 +9,7 @@ pub fn read_char() {
     }
 }
 
-pub fn read_line() {
+fn read_line() {
     let input = input();
 
     match input.read_line() {

--- a/examples/key_events.rs
+++ b/examples/key_events.rs
@@ -1,6 +1,6 @@
 use std::{thread, time::Duration};
 
-use crossterm::{input, InputEvent, KeyEvent, MouseButton, MouseEvent, RawScreen};
+use crossterm::{input, InputEvent, KeyEvent, MouseButton, MouseEvent, RawScreen, Result};
 
 fn process_input_event(key_event: InputEvent) -> bool {
     match key_event {
@@ -71,16 +71,16 @@ fn process_input_event(key_event: InputEvent) -> bool {
         _ => println!("Unknown!"),
     }
 
-    return false;
+    false
 }
 
-pub fn read_asynchronously() {
+pub fn read_asynchronously() -> Result<()> {
     // make sure to enable raw mode, this will make sure key events won't be handled by the terminal it's self and allows crossterm to read the input and pass it back to you.
-    if let Ok(_raw) = RawScreen::into_raw_mode() {
+    if let Ok(_) = RawScreen::into_raw_mode() {
         let input = input();
 
         // enable mouse events to be captured.
-        input.enable_mouse_mode().unwrap();
+        input.enable_mouse_mode()?;
 
         let mut stdin = input.read_async();
 
@@ -94,17 +94,18 @@ pub fn read_asynchronously() {
         }
 
         // disable mouse events to be captured.
-        input.disable_mouse_mode().unwrap();
+        input.disable_mouse_mode()?;
     } // <=== raw modes will be disabled here
+    Ok(())
 } // <=== background reader will be disposed when dropped.
 
-pub fn read_synchronously() {
+pub fn read_synchronously() -> Result<()> {
     // make sure to enable raw mode, this will make sure key events won't be handled by the terminal it's self and allows crossterm to read the input and pass it back to you.
-    if let Ok(_raw) = RawScreen::into_raw_mode() {
+    if let Ok(_) = RawScreen::into_raw_mode() {
         let input = input();
 
         // enable mouse events to be captured.
-        input.enable_mouse_mode().unwrap();
+        input.enable_mouse_mode()?;
 
         let mut sync_stdin = input.read_sync();
 
@@ -119,12 +120,13 @@ pub fn read_synchronously() {
         }
 
         // disable mouse events to be captured.
-        input.disable_mouse_mode().unwrap();
+        input.disable_mouse_mode()?;
     } // <=== raw modes will be disabled here
+    Ok(())
 }
 
 // cargo run --example key_events
-fn main() {
-    //    read_synchronously();
+fn main() -> Result<()> {
+    read_synchronously()
     //    read_asynchronously();
 }

--- a/examples/key_events.rs
+++ b/examples/key_events.rs
@@ -74,59 +74,57 @@ fn process_input_event(key_event: InputEvent) -> bool {
     false
 }
 
-pub fn read_asynchronously() -> Result<()> {
+fn read_asynchronously() -> Result<()> {
     // make sure to enable raw mode, this will make sure key events won't be handled by the terminal it's self and allows crossterm to read the input and pass it back to you.
-    if let Ok(_) = RawScreen::into_raw_mode() {
-        let input = input();
+    let _raw = RawScreen::into_raw_mode()?;
 
-        // enable mouse events to be captured.
-        input.enable_mouse_mode()?;
+    let input = input();
 
-        let mut stdin = input.read_async();
+    // enable mouse events to be captured.
+    input.enable_mouse_mode()?;
 
-        loop {
-            if let Some(key_event) = stdin.next() {
-                if process_input_event(key_event) {
-                    break;
-                }
-            }
-            thread::sleep(Duration::from_millis(50));
-        }
+    let mut stdin = input.read_async();
 
-        // disable mouse events to be captured.
-        input.disable_mouse_mode()?;
-    } // <=== raw modes will be disabled here
-    Ok(())
-} // <=== background reader will be disposed when dropped.
-
-pub fn read_synchronously() -> Result<()> {
-    // make sure to enable raw mode, this will make sure key events won't be handled by the terminal it's self and allows crossterm to read the input and pass it back to you.
-    if let Ok(_) = RawScreen::into_raw_mode() {
-        let input = input();
-
-        // enable mouse events to be captured.
-        input.enable_mouse_mode()?;
-
-        let mut sync_stdin = input.read_sync();
-
-        loop {
-            let event = sync_stdin.next();
-
-            if let Some(key_event) = event {
-                if process_input_event(key_event) {
-                    break;
-                }
+    loop {
+        if let Some(key_event) = stdin.next() {
+            if process_input_event(key_event) {
+                break;
             }
         }
+        thread::sleep(Duration::from_millis(50));
+    }
 
-        // disable mouse events to be captured.
-        input.disable_mouse_mode()?;
-    } // <=== raw modes will be disabled here
-    Ok(())
-}
+    // disable mouse events to be captured.
+    input.disable_mouse_mode()
+} // <=== raw modes will be disabled here
+
+fn read_synchronously() -> Result<()> {
+    // make sure to enable raw mode, this will make sure key events won't be handled by the terminal it's self and allows crossterm to read the input and pass it back to you.
+    let _raw = RawScreen::into_raw_mode()?;
+
+    let input = input();
+
+    // enable mouse events to be captured.
+    input.enable_mouse_mode()?;
+
+    let mut sync_stdin = input.read_sync();
+
+    loop {
+        let event = sync_stdin.next();
+
+        if let Some(key_event) = event {
+            if process_input_event(key_event) {
+                break;
+            }
+        }
+    }
+
+    // disable mouse events to be captured.
+    input.disable_mouse_mode()
+} // <=== raw modes will be disabled here
 
 // cargo run --example key_events
 fn main() -> Result<()> {
     read_synchronously()
-    //    read_asynchronously();
+    // read_asynchronously()
 }

--- a/examples/key_events.rs
+++ b/examples/key_events.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::{thread, time::Duration};
 
 use crossterm::{input, InputEvent, KeyEvent, MouseButton, MouseEvent, RawScreen, Result};

--- a/examples/raw_mode.rs
+++ b/examples/raw_mode.rs
@@ -1,9 +1,9 @@
-use std::io::{self, stdout, Write};
+use std::io::{stdout, Write};
 use std::{thread, time};
 
-use crossterm::{style, AlternateScreen, ClearType, Color, Crossterm};
+use crossterm::{style, AlternateScreen, ClearType, Color, Crossterm, Result};
 
-fn print_wait_screen() -> io::Result<()> {
+fn print_wait_screen() -> Result<()> {
     let crossterm = Crossterm::new();
     let terminal = crossterm.terminal();
     let cursor = crossterm.cursor();
@@ -39,16 +39,12 @@ fn print_wait_screen() -> io::Result<()> {
     Ok(())
 }
 
-pub fn print_wait_screen_on_alternate_window() -> io::Result<()> {
+pub fn print_wait_screen_on_alternate_window() -> Result<()> {
     // by passing in 'true' the alternate screen will be in raw modes.
-    if let Ok(_alternate) = AlternateScreen::to_alternate(true) {
-        print_wait_screen()?;
-    } // <- drop alternate screen; this will cause the alternate screen to drop.
-
-    Ok(())
+    AlternateScreen::to_alternate(true).and_then(|_| print_wait_screen())
 }
 
 // cargo run --example raw_mode
-fn main() {
-    print_wait_screen_on_alternate_window().unwrap();
+fn main() -> Result<()> {
+    print_wait_screen_on_alternate_window()
 }

--- a/examples/raw_mode.rs
+++ b/examples/raw_mode.rs
@@ -39,9 +39,10 @@ fn print_wait_screen() -> Result<()> {
     Ok(())
 }
 
-pub fn print_wait_screen_on_alternate_window() -> Result<()> {
+fn print_wait_screen_on_alternate_window() -> Result<()> {
     // by passing in 'true' the alternate screen will be in raw modes.
-    AlternateScreen::to_alternate(true).and_then(|_| print_wait_screen())
+    let _alt = AlternateScreen::to_alternate(true)?;
+    print_wait_screen()
 }
 
 // cargo run --example raw_mode

--- a/examples/style.rs
+++ b/examples/style.rs
@@ -1,22 +1,25 @@
 //!
 //! Examples of coloring the terminal.
 //!
+
+#![allow(dead_code)]
+
 use crossterm::{color, Attribute, Color, Colored, Colorize, Styler};
 
 /// print some red text | demonstration.
-pub fn paint_foreground() {
+fn paint_foreground() {
     println!("{}", "Red foreground text: {}".red());
     println!("{} Red foreground text", Colored::Fg(Color::Red));
 }
 
 /// print some text on red background | demonstration.
-pub fn paint_background() {
+fn paint_background() {
     println!("{}", "Red background text: {}".on_red());
     println!("{} Red background text", Colored::Bg(Color::Red));
 }
 
 /// Print all available foreground colors | demonstration.
-pub fn print_all_foreground_colors_with_enum() {
+fn print_all_foreground_colors_with_enum() {
     // we use `Reset` to restore the foreground back to normal at the end of the line.
     println!(
         "Black : \t\t      {} ■ {}\n",
@@ -114,7 +117,7 @@ pub fn print_all_foreground_colors_with_enum() {
 }
 
 /// Print all available foreground colors | demonstration.
-pub fn print_all_foreground_colors_with_method() {
+fn print_all_foreground_colors_with_method() {
     println!(
         "Black : \t\t       {} {}\n",
         "■".black(),
@@ -182,7 +185,7 @@ pub fn print_all_foreground_colors_with_method() {
 }
 
 /// Print all available foreground colors | demonstration.
-pub fn print_all_background_colors_with_enum() {
+fn print_all_background_colors_with_enum() {
     println!(
         "Black : \t\t      {} ■ {}\n",
         Colored::Bg(Color::Black),
@@ -279,7 +282,7 @@ pub fn print_all_background_colors_with_enum() {
 }
 
 /// Print all available foreground colors | demonstration.
-pub fn print_all_background_colors_with_method() {
+fn print_all_background_colors_with_method() {
     println!(
         "Black : \t\t       {} {}\n",
         "■".on_black(),
@@ -364,7 +367,7 @@ pub fn print_all_background_colors_with_method() {
 
 /// Print text with all available attributes. Note that this can only be used at unix systems and that some are not supported widely | demonstration..
 #[cfg(unix)]
-pub fn print_text_with_attributes() {
+fn print_text_with_attributes() {
     println!("{}", "Normal text");
     println!("{}", "Bold text".bold());
     println!("{}", "Italic text".italic());
@@ -387,7 +390,7 @@ pub fn print_text_with_attributes() {
 
 // Print text with all available attributes. Note that this can only be used at unix systems and that some are not supported widely | demonstration..
 #[cfg(windows)]
-pub fn print_text_with_attributes() {
+fn print_text_with_attributes() {
     println!("{}", "Normal text");
     println!("{}", "Bold text".bold());
     println!("{}", "Underlined text".underlined());
@@ -395,7 +398,7 @@ pub fn print_text_with_attributes() {
 }
 
 /// Print all supported RGB colors, not supported for Windows systems < 10  | demonstration.
-pub fn print_supported_colors() {
+fn print_supported_colors() {
     let count = color().get_available_color_count().unwrap();
 
     for i in 0..count {
@@ -403,7 +406,7 @@ pub fn print_supported_colors() {
     }
 }
 
-pub fn reset_fg_and_bg() {
+fn reset_fg_and_bg() {
     println!("{}", Colored::Fg(Color::Reset));
     println!("{}", Colored::Bg(Color::Reset));
 }

--- a/examples/terminal.rs
+++ b/examples/terminal.rs
@@ -2,6 +2,8 @@
 //! Terminal Examples
 //!
 
+#![allow(dead_code)]
+
 use crossterm::{cursor, terminal, ClearType, Result};
 
 fn print_test_data() {
@@ -11,7 +13,7 @@ fn print_test_data() {
 }
 
 /// Clear all lines in terminal | demonstration
-pub fn clear_all_lines() -> Result<()> {
+fn clear_all_lines() -> Result<()> {
     let terminal = terminal();
 
     print_test_data();
@@ -21,7 +23,7 @@ pub fn clear_all_lines() -> Result<()> {
 }
 
 /// Clear all lines from cursor position X:4, Y:4 down | demonstration
-pub fn clear_from_cursor_down() -> Result<()> {
+fn clear_from_cursor_down() -> Result<()> {
     let terminal = terminal();
 
     print_test_data();
@@ -34,7 +36,7 @@ pub fn clear_from_cursor_down() -> Result<()> {
 }
 
 /// Clear all lines from cursor position X:4, Y:4 up | demonstration
-pub fn clear_from_cursor_up() -> Result<()> {
+fn clear_from_cursor_up() -> Result<()> {
     let terminal = terminal();
 
     print_test_data();
@@ -47,7 +49,7 @@ pub fn clear_from_cursor_up() -> Result<()> {
 }
 
 /// Clear all lines from cursor position X:4, Y:4 up | demonstration
-pub fn clear_current_line() -> Result<()> {
+fn clear_current_line() -> Result<()> {
     let terminal = terminal();
 
     print_test_data();
@@ -60,7 +62,7 @@ pub fn clear_current_line() -> Result<()> {
 }
 
 /// Clear all lines from cursor position X:4, Y:7 up | demonstration
-pub fn clear_until_new_line() -> Result<()> {
+fn clear_until_new_line() -> Result<()> {
     let terminal = terminal();
 
     print_test_data();
@@ -73,7 +75,7 @@ pub fn clear_until_new_line() -> Result<()> {
 }
 
 /// Print the the current terminal size | demonstration.
-pub fn print_terminal_size() {
+fn print_terminal_size() {
     let terminal = terminal();
 
     // Get terminal size
@@ -84,14 +86,14 @@ pub fn print_terminal_size() {
 }
 
 /// Set the terminal size to width 10, height: 10 | demonstration.
-pub fn set_terminal_size() -> Result<()> {
+fn set_terminal_size() -> Result<()> {
     let terminal = terminal();
 
     terminal.set_size(10, 10)
 }
 
 /// Scroll down 10 lines | demonstration.
-pub fn scroll_down() -> Result<()> {
+fn scroll_down() -> Result<()> {
     let terminal = terminal();
 
     print_test_data();
@@ -101,7 +103,7 @@ pub fn scroll_down() -> Result<()> {
 }
 
 /// Scroll down 10 lines | demonstration.
-pub fn scroll_up() -> Result<()> {
+fn scroll_up() -> Result<()> {
     let terminal = terminal();
 
     print_test_data();
@@ -111,7 +113,7 @@ pub fn scroll_up() -> Result<()> {
 }
 
 /// exit the current proccess.
-pub fn exit() {
+fn exit() {
     let terminal = terminal();
     terminal.exit();
 }

--- a/examples/terminal.rs
+++ b/examples/terminal.rs
@@ -2,9 +2,7 @@
 //! Terminal Examples
 //!
 
-use std::io;
-
-use crossterm::{cursor, terminal, ClearType};
+use crossterm::{cursor, terminal, ClearType, Result};
 
 fn print_test_data() {
     for i in 0..100 {
@@ -13,19 +11,17 @@ fn print_test_data() {
 }
 
 /// Clear all lines in terminal | demonstration
-pub fn clear_all_lines() -> io::Result<()> {
+pub fn clear_all_lines() -> Result<()> {
     let terminal = terminal();
 
     print_test_data();
 
     // Clear all lines in terminal;
-    terminal.clear(ClearType::All)?;
-
-    Ok(())
+    terminal.clear(ClearType::All)
 }
 
 /// Clear all lines from cursor position X:4, Y:4 down | demonstration
-pub fn clear_from_cursor_down() -> io::Result<()> {
+pub fn clear_from_cursor_down() -> Result<()> {
     let terminal = terminal();
 
     print_test_data();
@@ -34,13 +30,11 @@ pub fn clear_from_cursor_down() -> io::Result<()> {
     cursor().goto(4, 8)?;
 
     // Clear all cells from current cursor position down.
-    terminal.clear(ClearType::FromCursorDown)?;
-
-    Ok(())
+    terminal.clear(ClearType::FromCursorDown)
 }
 
 /// Clear all lines from cursor position X:4, Y:4 up | demonstration
-pub fn clear_from_cursor_up() -> io::Result<()> {
+pub fn clear_from_cursor_up() -> Result<()> {
     let terminal = terminal();
 
     print_test_data();
@@ -49,13 +43,11 @@ pub fn clear_from_cursor_up() -> io::Result<()> {
     cursor().goto(4, 4)?;
 
     // Clear all cells from current cursor position down.
-    terminal.clear(ClearType::FromCursorUp)?;
-
-    Ok(())
+    terminal.clear(ClearType::FromCursorUp)
 }
 
 /// Clear all lines from cursor position X:4, Y:4 up | demonstration
-pub fn clear_current_line() -> io::Result<()> {
+pub fn clear_current_line() -> Result<()> {
     let terminal = terminal();
 
     print_test_data();
@@ -64,13 +56,11 @@ pub fn clear_current_line() -> io::Result<()> {
     cursor().goto(4, 3)?;
 
     // Clear current line cells.
-    terminal.clear(ClearType::CurrentLine)?;
-
-    Ok(())
+    terminal.clear(ClearType::CurrentLine)
 }
 
 /// Clear all lines from cursor position X:4, Y:7 up | demonstration
-pub fn clear_until_new_line() -> io::Result<()> {
+pub fn clear_until_new_line() -> Result<()> {
     let terminal = terminal();
 
     print_test_data();
@@ -79,9 +69,7 @@ pub fn clear_until_new_line() -> io::Result<()> {
     cursor().goto(4, 20)?;
 
     // Clear all the cells until next line.
-    terminal.clear(ClearType::UntilNewLine)?;
-
-    Ok(())
+    terminal.clear(ClearType::UntilNewLine)
 }
 
 /// Print the the current terminal size | demonstration.
@@ -96,36 +84,30 @@ pub fn print_terminal_size() {
 }
 
 /// Set the terminal size to width 10, height: 10 | demonstration.
-pub fn set_terminal_size() -> io::Result<()> {
+pub fn set_terminal_size() -> Result<()> {
     let terminal = terminal();
 
-    terminal.set_size(10, 10)?;
-
-    Ok(())
+    terminal.set_size(10, 10)
 }
 
 /// Scroll down 10 lines | demonstration.
-pub fn scroll_down() -> io::Result<()> {
+pub fn scroll_down() -> Result<()> {
     let terminal = terminal();
 
     print_test_data();
 
     // Scroll down 10 lines.
-    terminal.scroll_down(10)?;
-
-    Ok(())
+    terminal.scroll_down(10)
 }
 
 /// Scroll down 10 lines | demonstration.
-pub fn scroll_up() -> io::Result<()> {
+pub fn scroll_up() -> Result<()> {
     let terminal = terminal();
 
     print_test_data();
 
     // Scroll up 10 lines.
-    terminal.scroll_up(5)?;
-
-    Ok(())
+    terminal.scroll_up(10)
 }
 
 /// exit the current proccess.
@@ -135,8 +117,6 @@ pub fn exit() {
 }
 
 // cargo run --example terminal
-fn main() -> io::Result<()> {
-    scroll_down()?;
-
-    Ok(())
+fn main() -> Result<()> {
+    scroll_down()
 }


### PR DESCRIPTION
* All functions in all crates (except `crossterm_winapi`) returns `crossterm::Result` (`io::Result` removed)
* Only the `crossterm_winapi` crate functions returns `io::Result`
  * `Result<T, ErrorKind>` is defined in the `crossterm_utils`, which is not accessible from (`-winapi`)

Fixes #229 
