### PR TITLE
Add \r back for the KeyEvent::Enter

### DIFF
--- a/crossterm_input/src/input.rs
+++ b/crossterm_input/src/input.rs
@@ -98,6 +98,7 @@ pub enum KeyEvent {
     End,
     PageUp,
     PageDown,
+    Tab,
     BackTab,
     Delete,
     Insert,

--- a/crossterm_input/src/input/unix_input.rs
+++ b/crossterm_input/src/input/unix_input.rs
@@ -266,7 +266,7 @@ where
                 None => InputEvent::Keyboard(KeyEvent::Esc),
             }
         }
-        b'\n' => InputEvent::Keyboard(KeyEvent::Enter),
+        b'\r' | b'\n' => InputEvent::Keyboard(KeyEvent::Enter),
         b'\t' => InputEvent::Keyboard(KeyEvent::Char('\t')),
         b'\x7F' => InputEvent::Keyboard(KeyEvent::Backspace),
         c @ b'\x01'..=b'\x1A' => {

--- a/crossterm_input/src/input/unix_input.rs
+++ b/crossterm_input/src/input/unix_input.rs
@@ -267,7 +267,7 @@ where
             }
         }
         b'\r' | b'\n' => InputEvent::Keyboard(KeyEvent::Enter),
-        b'\t' => InputEvent::Keyboard(KeyEvent::Char('\t')),
+        b'\t' => InputEvent::Keyboard(KeyEvent::Tab),
         b'\x7F' => InputEvent::Keyboard(KeyEvent::Backspace),
         c @ b'\x01'..=b'\x1A' => {
             InputEvent::Keyboard(KeyEvent::Ctrl((c as u8 - 0x1 + b'a') as char))

--- a/crossterm_input/src/input/windows_input.rs
+++ b/crossterm_input/src/input/windows_input.rs
@@ -397,7 +397,7 @@ fn parse_key_event_record(key_event: &KeyEventRecord) -> Option<KeyEvent> {
                     if character == '\t' {
                         Some(KeyEvent::BackTab)
                     } else {
-                        Some(KeyEvent::Char(character))
+                        Some(KeyEvent::Tab)
                     }
                 } else {
                     Some(KeyEvent::Char(character))


### PR DESCRIPTION
Actually, that's my mistake. When I said that the `\r` is useless on Unix, I was right & wrong. In raw mode, the Enter key sends CR and the terminal driver translates this to the new line. I've just tested this and without the `\r`, the input event is CTRL-M, which is Enter. When added back, it's correctly translated to the `KeyEvent::Enter`. Sorry for introducing this bug.

Introduce `KeyEvent::Tab` mentioned in the #236.