### PR TITLE
Cleanup 3

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @TimonPost

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ cursor.goto(5,20);
 // Print at X: 5 Y: 20.
 print!("Yea!");
 // Reset back to X: 5 Y: 5.
-cursor.reset_position();
+cursor.restore_position();
 // Print 'Back' at X: 5 Y: 5.
 print!("Back");
 

--- a/crossterm_cursor/README.md
+++ b/crossterm_cursor/README.md
@@ -106,7 +106,7 @@ cursor.goto(5,20);
 // Print at X: 5 Y: 20.
 print!("Yea!");
 // Reset back to X: 5 Y: 5.
-cursor.reset_position();
+cursor.restore_position();
 // Print 'Back' at X: 5 Y: 5.
 print!("Back");
 

--- a/crossterm_cursor/src/cursor.rs
+++ b/crossterm_cursor/src/cursor.rs
@@ -42,7 +42,7 @@ trait ITerminalCursor: Sync + Send {
     /// is stored program based not per instance of the cursor struct.
     fn save_position(&self) -> Result<()>;
     /// Return to saved cursor position
-    fn reset_position(&self) -> Result<()>;
+    fn restore_position(&self) -> Result<()>;
     /// Hide the terminal cursor.
     fn hide(&self) -> Result<()>;
     /// Show the terminal cursor

--- a/crossterm_cursor/src/cursor/cursor.rs
+++ b/crossterm_cursor/src/cursor/cursor.rs
@@ -131,7 +131,7 @@ pub struct Goto(pub u16, pub u16);
 impl Command for Goto {
     type AnsiType = String;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         ansi_cursor::get_goto_ansi(self.0, self.1)
     }
 
@@ -149,7 +149,7 @@ pub struct Up(pub u16);
 impl Command for Up {
     type AnsiType = String;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         ansi_cursor::get_move_up_ansi(self.0)
     }
 
@@ -167,7 +167,7 @@ pub struct Down(pub u16);
 impl Command for Down {
     type AnsiType = String;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         ansi_cursor::get_move_down_ansi(self.0)
     }
 
@@ -185,7 +185,7 @@ pub struct Left(pub u16);
 impl Command for Left {
     type AnsiType = String;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         ansi_cursor::get_move_left_ansi(self.0)
     }
 
@@ -203,7 +203,7 @@ pub struct Right(pub u16);
 impl Command for Right {
     type AnsiType = String;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         ansi_cursor::get_move_right_ansi(self.0)
     }
 
@@ -223,7 +223,7 @@ pub struct SavePos;
 impl Command for SavePos {
     type AnsiType = &'static str;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         ansi_cursor::SAVE_POS_ANSI
     }
 
@@ -241,7 +241,7 @@ pub struct ResetPos;
 impl Command for ResetPos {
     type AnsiType = &'static str;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         ansi_cursor::RESTORE_POS_ANSI
     }
 
@@ -259,7 +259,7 @@ pub struct Hide;
 impl Command for Hide {
     type AnsiType = &'static str;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         ansi_cursor::HIDE_ANSI
     }
 
@@ -277,7 +277,7 @@ pub struct Show;
 impl Command for Show {
     type AnsiType = &'static str;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         ansi_cursor::SHOW_ANSI
     }
 
@@ -298,7 +298,7 @@ pub struct BlinkOn;
 impl Command for BlinkOn {
     type AnsiType = &'static str;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         ansi_cursor::BLINK_ON_ANSI
     }
 
@@ -319,7 +319,7 @@ pub struct BlinkOff;
 impl Command for BlinkOff {
     type AnsiType = &'static str;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         ansi_cursor::BLINK_OFF_ANSI
     }
 

--- a/crossterm_cursor/src/cursor/cursor.rs
+++ b/crossterm_cursor/src/cursor/cursor.rs
@@ -95,8 +95,8 @@ impl TerminalCursor {
     }
 
     /// Return to saved cursor position
-    pub fn reset_position(&self) -> Result<()> {
-        self.cursor.reset_position()
+    pub fn restore_position(&self) -> Result<()> {
+        self.cursor.restore_position()
     }
 
     /// Hide de cursor in the console.
@@ -224,7 +224,7 @@ impl Command for SavePos {
     type AnsiType = &'static str;
 
     fn get_ansi_code(&self) -> Self::AnsiType {
-        ansi_cursor::SAFE_POS_ANSI
+        ansi_cursor::SAVE_POS_ANSI
     }
 
     #[cfg(windows)]
@@ -242,12 +242,12 @@ impl Command for ResetPos {
     type AnsiType = &'static str;
 
     fn get_ansi_code(&self) -> Self::AnsiType {
-        ansi_cursor::RESET_POS_ANSI
+        ansi_cursor::RESTORE_POS_ANSI
     }
 
     #[cfg(windows)]
     fn execute_winapi(&self) -> Result<()> {
-        WinApiCursor::new().reset_position()
+        WinApiCursor::new().restore_position()
     }
 }
 

--- a/crossterm_cursor/src/sys/unix.rs
+++ b/crossterm_cursor/src/sys/unix.rs
@@ -26,7 +26,7 @@ pub fn show_cursor(show_cursor: bool) -> Result<()> {
 }
 
 pub fn pos() -> Result<(u16, u16)> {
-    unix::into_raw_mode()?;
+    unix::enable_raw_mode()?;
     let pos = pos_raw();
     unix::disable_raw_mode()?;
     pos

--- a/crossterm_cursor/src/sys/winapi.rs
+++ b/crossterm_cursor/src/sys/winapi.rs
@@ -67,7 +67,7 @@ impl Cursor {
 
         unsafe {
             if !is_true(SetConsoleCursorPosition(
-                **self.screen_buffer.get_handle(),
+                **self.screen_buffer.handle(),
                 position,
             )) {
                 Err(io::Error::last_os_error())?;
@@ -85,7 +85,7 @@ impl Cursor {
 
         unsafe {
             if !is_true(SetConsoleCursorInfo(
-                **self.screen_buffer.get_handle(),
+                **self.screen_buffer.handle(),
                 &cursor_info,
             )) {
                 Err(io::Error::last_os_error())?;

--- a/crossterm_cursor/src/sys/winapi.rs
+++ b/crossterm_cursor/src/sys/winapi.rs
@@ -95,7 +95,7 @@ impl Cursor {
     }
 
     /// Reset to saved cursor position
-    pub fn reset_to_saved_position() -> Result<()> {
+    pub fn restore_cursor_pos() -> Result<()> {
         let cursor = Cursor::new()?;
 
         unsafe {

--- a/crossterm_screen/src/sys/unix.rs
+++ b/crossterm_screen/src/sys/unix.rs
@@ -10,7 +10,7 @@ impl RawModeCommand {
 
     /// Enables raw mode.
     pub fn enable(&mut self) -> Result<()> {
-        crossterm_utils::sys::unix::into_raw_mode()?;
+        crossterm_utils::sys::unix::enable_raw_mode()?;
         Ok(())
     }
 

--- a/crossterm_screen/src/sys/winapi.rs
+++ b/crossterm_screen/src/sys/winapi.rs
@@ -63,7 +63,7 @@ impl ToAlternateScreenCommand {
 
 impl IAlternateScreenCommand for ToAlternateScreenCommand {
     fn enable(&self) -> Result<()> {
-        let alternate_screen = ScreenBuffer::create();
+        let alternate_screen = ScreenBuffer::new();
         alternate_screen.show()?;
         Ok(())
     }

--- a/crossterm_screen/src/sys/winapi.rs
+++ b/crossterm_screen/src/sys/winapi.rs
@@ -63,7 +63,7 @@ impl ToAlternateScreenCommand {
 
 impl IAlternateScreenCommand for ToAlternateScreenCommand {
     fn enable(&self) -> Result<()> {
-        let alternate_screen = ScreenBuffer::new();
+        let alternate_screen = ScreenBuffer::create();
         alternate_screen.show()?;
         Ok(())
     }

--- a/crossterm_style/src/color.rs
+++ b/crossterm_style/src/color.rs
@@ -70,7 +70,7 @@ impl TerminalColor {
     /// # Remarks
     ///
     /// This does not always provide a good result.
-    pub fn get_available_color_count(&self) -> u16 {
+    pub fn available_color_count(&self) -> u16 {
         env::var("TERM")
             .map(|x| if x.contains("256color") { 256 } else { 8 })
             .unwrap_or(8)
@@ -90,7 +90,7 @@ pub struct SetFg(pub Color);
 impl Command for SetFg {
     type AnsiType = String;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         ansi_color::get_set_fg_ansi(self.0)
     }
 
@@ -108,7 +108,7 @@ pub struct SetBg(pub Color);
 impl Command for SetBg {
     type AnsiType = String;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         ansi_color::get_set_bg_ansi(self.0)
     }
 
@@ -126,7 +126,7 @@ pub struct SetAttr(pub Attribute);
 impl Command for SetAttr {
     type AnsiType = String;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         ansi_color::get_set_attr_ansi(self.0)
     }
 
@@ -148,7 +148,7 @@ where
 {
     type AnsiType = StyledObject<D>;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         self.0.clone()
     }
 

--- a/crossterm_style/src/winapi_color.rs
+++ b/crossterm_style/src/winapi_color.rs
@@ -52,7 +52,7 @@ impl ITerminalColor for WinApiColor {
             color = color | wincon::BACKGROUND_INTENSITY as u16;
         }
 
-        Console::from(**screen_buffer.get_handle()).set_text_attribute(color)?;
+        Console::from(**screen_buffer.handle()).set_text_attribute(color)?;
 
         Ok(())
     }
@@ -79,7 +79,7 @@ impl ITerminalColor for WinApiColor {
             color = color | wincon::FOREGROUND_INTENSITY as u16;
         }
 
-        Console::from(**screen_buffer.get_handle()).set_text_attribute(color)?;
+        Console::from(**screen_buffer.handle()).set_text_attribute(color)?;
 
         Ok(())
     }

--- a/crossterm_terminal/src/terminal/ansi_terminal.rs
+++ b/crossterm_terminal/src/terminal/ansi_terminal.rs
@@ -88,21 +88,21 @@ mod tests {
     // TODO - Test is disabled, because it's failing on Travis CI
     #[test]
     #[ignore]
-    fn resize_ansi() {
+    fn test_resize_ansi() {
         if try_enable_ansi() {
             let terminal = AnsiTerminal::new();
 
-            assert!(terminal.set_size(50, 50).is_ok());
+            let (width, height) = terminal.size().unwrap();
 
+            terminal.set_size(30, 30).unwrap();
             // see issue: https://github.com/eminence/terminal-size/issues/11
             thread::sleep(time::Duration::from_millis(30));
+            assert_eq!((30, 30), terminal.size().unwrap());
 
-            let size = terminal.size();
-            assert!(size.is_ok());
-            let (x, y) = size.unwrap();
-
-            assert_eq!(x, 50);
-            assert_eq!(y, 50);
+            terminal.set_size(width, height).unwrap();
+            // see issue: https://github.com/eminence/terminal-size/issues/11
+            thread::sleep(time::Duration::from_millis(30));
+            assert_eq!((width, height), terminal.size().unwrap());
         }
     }
 

--- a/crossterm_terminal/src/terminal/terminal.rs
+++ b/crossterm_terminal/src/terminal/terminal.rs
@@ -145,7 +145,7 @@ pub struct ScrollUp(pub u16);
 impl Command for ScrollUp {
     type AnsiType = String;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         super::ansi_terminal::get_scroll_up_ansi(self.0)
     }
 
@@ -163,7 +163,7 @@ pub struct ScrollDown(pub u16);
 impl Command for ScrollDown {
     type AnsiType = String;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         super::ansi_terminal::get_scroll_down_ansi(self.0)
     }
 
@@ -181,7 +181,7 @@ pub struct Clear(pub ClearType);
 impl Command for Clear {
     type AnsiType = &'static str;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         match self.0 {
             ClearType::All => {
                 return super::ansi_terminal::CLEAR_ALL;
@@ -211,7 +211,7 @@ pub struct SetSize(pub u16, pub u16);
 impl Command for SetSize {
     type AnsiType = String;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         super::ansi_terminal::get_set_size_ansi(self.0, self.1)
     }
 

--- a/crossterm_terminal/src/terminal/winapi_terminal.rs
+++ b/crossterm_terminal/src/terminal/winapi_terminal.rs
@@ -283,16 +283,15 @@ mod tests {
     // TODO - Test is ignored, because it returns wrong result (31 != 30)
     #[test]
     #[ignore]
-    fn resize_winapi() {
+    fn test_resize_winapi() {
         let terminal = WinApiTerminal::new();
 
-        assert!(terminal.set_size(30, 30).is_ok());
+        let (width, height) = terminal.size().unwrap();
 
-        let size = terminal.size();
-        assert!(size.is_ok());
-        let (x, y) = size.unwrap();
+        terminal.set_size(30, 30).unwrap();
+        assert_eq!((30, 30), terminal.size().unwrap());
 
-        assert_eq!(x, 30);
-        assert_eq!(y, 30);
+        terminal.set_size(width, height).unwrap();
+        assert_eq!((width, height), terminal.size().unwrap());
     }
 }

--- a/crossterm_terminal/src/terminal/winapi_terminal.rs
+++ b/crossterm_terminal/src/terminal/winapi_terminal.rs
@@ -93,7 +93,7 @@ impl ITerminal for WinApiTerminal {
 
         // Get the position of the current console window
         let screen_buffer = ScreenBuffer::current()?;
-        let console = Console::from(**screen_buffer.get_handle());
+        let console = Console::from(**screen_buffer.handle());
         let csbi = screen_buffer.info()?;
 
         let current_size = csbi.buffer_size();

--- a/crossterm_utils/src/command.rs
+++ b/crossterm_utils/src/command.rs
@@ -17,7 +17,7 @@ pub trait Command {
     /// You are able to use ANSI escape codes only for windows 10 and UNIX systems.
     ///
     /// **This method is mainly used internally by crossterm!**
-    fn get_ansi_code(&self) -> Self::AnsiType;
+    fn ansi_code(&self) -> Self::AnsiType;
 
     /// Execute this command.
     ///
@@ -104,7 +104,7 @@ pub struct Output(pub String);
 impl Command for Output {
     type AnsiType = String;
 
-    fn get_ansi_code(&self) -> Self::AnsiType {
+    fn ansi_code(&self) -> Self::AnsiType {
         return self.0.clone();
     }
 

--- a/crossterm_utils/src/functions.rs
+++ b/crossterm_utils/src/functions.rs
@@ -5,24 +5,15 @@ use crate::sys::winapi::ansi::set_virtual_terminal_processing;
 pub fn supports_ansi() -> bool {
     // Some terminals on windows like GitBash can't use WinaApi calls directly so when we try to enable the ANSI-flag for windows this won't work.
     // Because of that we should check first if the TERM-variable is set and see if the current terminal is a terminal who does support ANSI.
-    let supports_ansi = is_specific_term();
 
-    match supports_ansi {
-        true => {
-            return true;
-        }
-        false => {
-            // if it is not listed we should try with WinApi to check if we do support ANSI-codes.
-            match set_virtual_terminal_processing(true) {
-                Ok(_) => {
-                    return true;
-                }
-                Err(_) => {
-                    return false;
-                }
-            }
-        }
+    if is_specific_term() {
+        return true;
     }
+
+    // if it is not listed we should try with WinApi to check if we do support ANSI-codes.
+    set_virtual_terminal_processing(true)
+        .map(|_| true)
+        .unwrap_or(false)
 }
 
 // checks if the 'TERM' environment variable is set to check if the terminal supports ANSI-codes.

--- a/crossterm_utils/src/macros.rs
+++ b/crossterm_utils/src/macros.rs
@@ -80,7 +80,7 @@ macro_rules! queue {
             #[cfg(windows)]
             {
                 if $crate::supports_ansi() {
-                    match write!($write, "{}", $command.get_ansi_code()) {
+                    match write!($write, "{}", $command.ansi_code()) {
                         Err(e) => {
                             error = Some(Err($crate::ErrorKind::from(e)));
                         }
@@ -96,7 +96,7 @@ macro_rules! queue {
                 };
             }
             #[cfg(unix)]
-            match write!($write, "{}", $command.get_ansi_code()) {
+            match write!($write, "{}", $command.ansi_code()) {
                 Err(e) => {
                     error = Some(Err($crate::ErrorKind::from(e)));
                 }
@@ -154,7 +154,7 @@ macro_rules! execute {
             #[cfg(windows)]
             {
                 if $crate::supports_ansi() {
-                    if let Err(e) = write_cout!($write, $command.get_ansi_code()) {
+                    if let Err(e) = write_cout!($write, $command.ansi_code()) {
                         error = Some($crate::ErrorKind::from(e));
                     };
                 } else {
@@ -165,7 +165,7 @@ macro_rules! execute {
             }
             #[cfg(unix)]
             {
-                if let Err(e) = write_cout!($write, $command.get_ansi_code()) {
+                if let Err(e) = write_cout!($write, $command.ansi_code()) {
                     error = Some($crate::ErrorKind::from(e));
                 }
             }
@@ -185,7 +185,7 @@ macro_rules! impl_display {
         $(impl ::std::fmt::Display for $t {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
                 use $crate::Command;
-                write!(f, "{}", self.get_ansi_code())
+                write!(f, "{}", self.ansi_code())
             }
         })*
     }

--- a/crossterm_utils/src/sys/unix.rs
+++ b/crossterm_utils/src/sys/unix.rs
@@ -43,7 +43,7 @@ pub fn set_terminal_attr(termios: &Termios) -> Result<()> {
     wrap_with_result(unsafe { tcsetattr(0, 0, termios) })
 }
 
-pub fn into_raw_mode() -> Result<()> {
+pub fn enable_raw_mode() -> Result<()> {
     let mut ios = get_terminal_attr()?;
     let prev_ios = ios;
 

--- a/crossterm_winapi/examples/cw_coloring_example.rs
+++ b/crossterm_winapi/examples/cw_coloring_example.rs
@@ -16,7 +16,7 @@ fn set_background_color() -> std::io::Result<()> {
     let new_color = fg_color | BLUE_BACKGROUND;
 
     // set the console text attribute to the new color value.
-    Console::from(**screen_buffer.get_handle()).set_text_attribute(new_color)?;
+    Console::from(**screen_buffer.handle()).set_text_attribute(new_color)?;
 
     Ok(())
 }
@@ -41,7 +41,7 @@ fn set_foreground_color() -> std::io::Result<()> {
     }
 
     // set the console text attribute to the new color value.
-    Console::from(**screen_buffer.get_handle()).set_text_attribute(color)?;
+    Console::from(**screen_buffer.handle()).set_text_attribute(color)?;
 
     Ok(())
 }

--- a/crossterm_winapi/examples/cw_coloring_example.rs
+++ b/crossterm_winapi/examples/cw_coloring_example.rs
@@ -49,6 +49,6 @@ fn set_foreground_color() -> Result<()> {
 }
 
 fn main() -> Result<()> {
-    set_background_color()?
+    set_background_color()?;
     set_foreground_color()
 }

--- a/crossterm_winapi/examples/cw_coloring_example.rs
+++ b/crossterm_winapi/examples/cw_coloring_example.rs
@@ -1,6 +1,8 @@
+use std::io::Result;
+
 use crossterm_winapi::{Console, ScreenBuffer};
 
-fn set_background_color() -> std::io::Result<()> {
+fn set_background_color() -> Result<()> {
     // background value
     const BLUE_BACKGROUND: u16 = 0x0010;
 
@@ -21,7 +23,7 @@ fn set_background_color() -> std::io::Result<()> {
     Ok(())
 }
 
-fn set_foreground_color() -> std::io::Result<()> {
+fn set_foreground_color() -> Result<()> {
     // background value
     const BLUE_FOREGROUND: u16 = 0x0001;
 
@@ -46,7 +48,7 @@ fn set_foreground_color() -> std::io::Result<()> {
     Ok(())
 }
 
-fn main() {
-    set_background_color().unwrap();
-    set_foreground_color().unwrap();
+fn main() -> Result<()> {
+    set_background_color()?
+    set_foreground_color()
 }

--- a/crossterm_winapi/examples/cw_console.rs
+++ b/crossterm_winapi/examples/cw_console.rs
@@ -1,17 +1,17 @@
+use std::io::Result;
+
 use crossterm_winapi::ConsoleMode;
 
-fn change_console_mode() {
-    let console_mode = ConsoleMode::new().unwrap();
+fn change_console_mode() -> Result<()> {
+    let console_mode = ConsoleMode::new()?;
 
     // get the current console mode:
-    let _mode: u32 = console_mode.mode().unwrap();
+    let _mode: u32 = console_mode.mode()?;
 
     // set the console mode (not sure if this is an actual value xp)
-    console_mode
-        .set_mode(10)
-        .expect("Unable to set console mode");
+    console_mode.set_mode(10)
 }
 
-fn main() {
-    change_console_mode();
+fn main() -> Result<()> {
+    change_console_mode()
 }

--- a/crossterm_winapi/examples/cw_handle.rs
+++ b/crossterm_winapi/examples/cw_handle.rs
@@ -1,12 +1,14 @@
+use std::io::Result;
+
 use crossterm_winapi::{Handle, HandleType};
 
 #[allow(unused_variables)]
-fn main() {
+fn main() -> Result<()> {
     // see the description of the types to see what they do.
-    let out_put_handle = Handle::new(HandleType::OutputHandle).unwrap();
-    let out_put_handle = Handle::new(HandleType::InputHandle).unwrap();
-    let curr_out_put_handle = Handle::new(HandleType::CurrentOutputHandle).unwrap();
-    let curr_out_put_handle = Handle::new(HandleType::CurrentInputHandle).unwrap();
+    let out_put_handle = Handle::new(HandleType::OutputHandle)?;
+    let out_put_handle = Handle::new(HandleType::InputHandle)?;
+    let curr_out_put_handle = Handle::new(HandleType::CurrentOutputHandle)?;
+    let curr_out_put_handle = Handle::new(HandleType::CurrentInputHandle)?;
 
     // now you have this handle you might want to get the WinApi `HANDLE` it is wrapping.
     // you can do this by defencing.
@@ -15,4 +17,6 @@ fn main() {
 
     // you can also pass you own `HANDLE` to create an instance of `Handle`
     let handle = Handle::from(handle); /* winapi::um::winnt::HANDLE */
+
+    Ok(())
 }

--- a/crossterm_winapi/examples/cw_screen_buffer.rs
+++ b/crossterm_winapi/examples/cw_screen_buffer.rs
@@ -1,26 +1,31 @@
+#![allow(dead_code)]
+
+use std::io::Result;
+
 use crossterm_winapi::ScreenBuffer;
 
-fn print_screen_buffer_information() {
-    let screen_buffer = ScreenBuffer::current().unwrap();
+fn print_screen_buffer_information() -> Result<()> {
+    let screen_buffer = ScreenBuffer::current()?;
 
     // get console screen buffer information
-    let csbi = screen_buffer.info().unwrap();
+    let csbi = screen_buffer.info()?;
 
     println!("cursor post: {:?}", csbi.cursor_pos());
     println!("attributes: {:?}", csbi.attributes());
     println!("terminal window dimentions {:?}", csbi.terminal_window());
     println!("terminal size {:?}", csbi.terminal_size());
+
+    Ok(())
 }
 
-#[allow(dead_code)]
-fn multiple_screen_buffers() {
+fn multiple_screen_buffers() -> Result<()> {
     // create new screen buffer
     let screen_buffer = ScreenBuffer::create();
 
     // which to this screen buffer
-    screen_buffer.show().expect("Unable to show screen buffer");
+    screen_buffer.show()
 }
 
-fn main() {
-    print_screen_buffer_information();
+fn main() -> Result<()> {
+    print_screen_buffer_information()
 }

--- a/crossterm_winapi/examples/cw_screen_buffer.rs
+++ b/crossterm_winapi/examples/cw_screen_buffer.rs
@@ -15,7 +15,7 @@ fn print_screen_buffer_information() {
 #[allow(dead_code)]
 fn multiple_screen_buffers() {
     // create new screen buffer
-    let screen_buffer = ScreenBuffer::create();
+    let screen_buffer = ScreenBuffer::new();
 
     // which to this screen buffer
     screen_buffer.show().expect("Unable to show screen buffer");

--- a/crossterm_winapi/examples/cw_screen_buffer.rs
+++ b/crossterm_winapi/examples/cw_screen_buffer.rs
@@ -15,7 +15,7 @@ fn print_screen_buffer_information() {
 #[allow(dead_code)]
 fn multiple_screen_buffers() {
     // create new screen buffer
-    let screen_buffer = ScreenBuffer::new();
+    let screen_buffer = ScreenBuffer::create();
 
     // which to this screen buffer
     screen_buffer.show().expect("Unable to show screen buffer");

--- a/crossterm_winapi/src/console_mode.rs
+++ b/crossterm_winapi/src/console_mode.rs
@@ -82,16 +82,15 @@ mod tests {
     // TODO - Test is ignored, because it's failing on Travis CI
     #[test]
     #[ignore]
-    fn set_get_mode() {
+    fn test_set_get_mode() {
         let mode = ConsoleMode::new().unwrap();
 
         let original_mode = mode.mode().unwrap();
 
-        assert!(mode.set_mode(0x0004).is_ok());
+        mode.set_mode(0x0004).unwrap();
         let console_mode = mode.mode().unwrap();
+        assert_eq!(console_mode & 0x0004, mode.mode().unwrap());
 
-        assert_ne!(console_mode & 0x0004, 0);
-
-        assert!(mode.set_mode(original_mode).is_ok());
+        mode.set_mode(original_mode).unwrap();
     }
 }

--- a/crossterm_winapi/src/handle.rs
+++ b/crossterm_winapi/src/handle.rs
@@ -179,7 +179,7 @@ mod tests {
     use super::{Handle, HandleType};
 
     #[test]
-    fn get_handle() {
+    fn test_get_handle() {
         assert!(Handle::new(HandleType::OutputHandle).is_ok());
         assert!(Handle::new(HandleType::InputHandle).is_ok());
         assert!(Handle::new(HandleType::CurrentOutputHandle).is_ok());

--- a/crossterm_winapi/src/screen_buffer.rs
+++ b/crossterm_winapi/src/screen_buffer.rs
@@ -102,7 +102,7 @@ impl ScreenBuffer {
     }
 
     /// Get the underlining raw `HANDLE` used by this type to execute whit.
-    pub fn get_handle(&self) -> &Handle {
+    pub fn handle(&self) -> &Handle {
         return &self.handle;
     }
 }

--- a/crossterm_winapi/src/screen_buffer.rs
+++ b/crossterm_winapi/src/screen_buffer.rs
@@ -34,7 +34,7 @@ impl ScreenBuffer {
     ///
     /// Wraps the underlying function call: [CreateConsoleScreenBuffer]
     /// link: [https://docs.microsoft.com/en-us/windows/console/createconsolescreenbuffer]
-    pub fn new() -> ScreenBuffer {
+    pub fn create() -> ScreenBuffer {
         let mut security_attr: SECURITY_ATTRIBUTES = SECURITY_ATTRIBUTES {
             nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
             lpSecurityDescriptor: NULL,

--- a/crossterm_winapi/src/screen_buffer.rs
+++ b/crossterm_winapi/src/screen_buffer.rs
@@ -126,7 +126,7 @@ mod tests {
     use super::ScreenBuffer;
 
     #[test]
-    fn screen_buffer_info() {
+    fn test_screen_buffer_info() {
         let buffer = ScreenBuffer::current().unwrap();
         let info = buffer.info().unwrap();
         info.terminal_size();

--- a/crossterm_winapi/src/screen_buffer.rs
+++ b/crossterm_winapi/src/screen_buffer.rs
@@ -34,7 +34,7 @@ impl ScreenBuffer {
     ///
     /// Wraps the underlying function call: [CreateConsoleScreenBuffer]
     /// link: [https://docs.microsoft.com/en-us/windows/console/createconsolescreenbuffer]
-    pub fn create() -> ScreenBuffer {
+    pub fn new() -> ScreenBuffer {
         let mut security_attr: SECURITY_ATTRIBUTES = SECURITY_ATTRIBUTES {
             nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
             lpSecurityDescriptor: NULL,

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -62,7 +62,7 @@ fn move_left() -> Result<()> {
 }
 
 /// Save and reset cursor position | demonstration..
-fn save_and_reset_position() -> Result<()> {
+fn save_and_restore_position() -> Result<()> {
     let cursor = cursor();
 
     // Goto X: 5 Y: 5
@@ -74,7 +74,7 @@ fn save_and_reset_position() -> Result<()> {
     // Print at X: 5 Y: 20.
     println!("Yea!");
     // Reset back to X: 5 Y: 5.
-    cursor.reset_position()?;
+    cursor.restore_position()?;
     // Print Back at X: 5 Y: 5.
     println!("Back");
 

--- a/examples/style.rs
+++ b/examples/style.rs
@@ -399,7 +399,7 @@ fn print_text_with_attributes() {
 
 /// Print all supported RGB colors, not supported for Windows systems < 10  | demonstration.
 fn print_supported_colors() {
-    let count = color().get_available_color_count();
+    let count = color().available_color_count();
 
     for i in 0..count {
         println!("Test {}", Colored::Bg(Color::AnsiValue(i as u8)));


### PR DESCRIPTION
* Not all tests were starting with the `test_` prefix
* It's not necessary to check for `is_ok()` in tests, simple `unwrap()` is enough
* Some tests were _rewritten_
* `TerminalCursor::reset_position()` renamed to `restore_position()`
  * I read `reset_position` as a _set it to (0, 0)_ or something like this.
  * `restore` is much more clear.
* Removed `get_` prefixes from methods (not from functions)
* ~Renamed `ScreenBuffer::create()` -> `new()`~