### PR TITLE
Unit tests

### DIFF
--- a/crossterm_cursor/src/cursor/ansi_cursor.rs
+++ b/crossterm_cursor/src/cursor/ansi_cursor.rs
@@ -110,7 +110,6 @@ mod tests {
 
     // TODO - Test is ingored, because it's stalled on Travis CI
     #[test]
-    #[ignore]
     fn test_ansi_save_restore_position() {
         if try_enable_ansi() {
             let cursor = AnsiCursor::new();
@@ -130,7 +129,6 @@ mod tests {
 
     // TODO - Test is ingored, because it's stalled on Travis CI
     #[test]
-    #[ignore]
     fn test_ansi_goto() {
         if try_enable_ansi() {
             let cursor = AnsiCursor::new();

--- a/crossterm_cursor/src/cursor/ansi_cursor.rs
+++ b/crossterm_cursor/src/cursor/ansi_cursor.rs
@@ -110,6 +110,7 @@ mod tests {
 
     // TODO - Test is ingored, because it's stalled on Travis CI
     #[test]
+    #[ignore]
     fn test_ansi_save_restore_position() {
         if try_enable_ansi() {
             let cursor = AnsiCursor::new();
@@ -129,6 +130,7 @@ mod tests {
 
     // TODO - Test is ingored, because it's stalled on Travis CI
     #[test]
+    #[ignore]
     fn test_ansi_goto() {
         if try_enable_ansi() {
             let cursor = AnsiCursor::new();

--- a/crossterm_terminal/src/sys/winapi.rs
+++ b/crossterm_terminal/src/sys/winapi.rs
@@ -10,5 +10,8 @@ pub fn exit() {
 pub fn get_terminal_size() -> Result<(u16, u16)> {
     let terminal_size = ScreenBuffer::current()?.info()?.terminal_size();
     // windows starts counting at 0, unix at 1, add one to replicated unix behaviour.
-    Ok(((terminal_size.width + 1) as u16, (terminal_size.height + 1) as u16))
+    Ok((
+        (terminal_size.width + 1) as u16,
+        (terminal_size.height + 1) as u16,
+    ))
 }

--- a/crossterm_terminal/src/sys/winapi.rs
+++ b/crossterm_terminal/src/sys/winapi.rs
@@ -8,6 +8,7 @@ pub fn exit() {
 
 #[cfg(windows)]
 pub fn get_terminal_size() -> Result<(u16, u16)> {
-    let buffer = ScreenBuffer::current()?;
-    Ok(buffer.info()?.terminal_size().into())
+    let terminal_size = ScreenBuffer::current()?.info()?.terminal_size();
+    // windows starts counting at 0, unix at 1, add one to replicated unix behaviour.
+    Ok(((terminal_size.width + 1) as u16, (terminal_size.height + 1) as u16))
 }

--- a/crossterm_terminal/src/terminal/ansi_terminal.rs
+++ b/crossterm_terminal/src/terminal/ansi_terminal.rs
@@ -85,20 +85,19 @@ mod tests {
     use super::{AnsiTerminal, ITerminal};
 
     /* ======================== ANSI =========================== */
-    // TODO - Test is disabled, because it's failing on Travis CI
     #[test]
-    #[ignore]
     fn test_resize_ansi() {
         if try_enable_ansi() {
             let terminal = AnsiTerminal::new();
 
             let (width, height) = terminal.size().unwrap();
 
-            terminal.set_size(30, 30).unwrap();
+            terminal.set_size(35, 35).unwrap();
             // see issue: https://github.com/eminence/terminal-size/issues/11
             thread::sleep(time::Duration::from_millis(30));
-            assert_eq!((30, 30), terminal.size().unwrap());
+            assert_eq!((35, 35), terminal.size().unwrap());
 
+            // reset to previous size
             terminal.set_size(width, height).unwrap();
             // see issue: https://github.com/eminence/terminal-size/issues/11
             thread::sleep(time::Duration::from_millis(30));

--- a/crossterm_terminal/src/terminal/ansi_terminal.rs
+++ b/crossterm_terminal/src/terminal/ansi_terminal.rs
@@ -86,6 +86,8 @@ mod tests {
 
     /* ======================== ANSI =========================== */
     #[test]
+    // TODO - Test is disabled, because it's failing on Travis CI
+    #[ignore]
     fn test_resize_ansi() {
         if try_enable_ansi() {
             let terminal = AnsiTerminal::new();

--- a/crossterm_terminal/src/terminal/winapi_terminal.rs
+++ b/crossterm_terminal/src/terminal/winapi_terminal.rs
@@ -128,8 +128,12 @@ impl ITerminal for WinApiTerminal {
             resize_buffer = true;
         }
 
+        println!("{:?}", new_size);
+        println!("{:?}",current_size);
+        println!("{:?}",window);
+
         if resize_buffer {
-            if let Err(_) = screen_buffer.set_size(new_size.width, new_size.height) {
+            if let Err(_) = screen_buffer.set_size(new_size.width - 1, new_size.height - 1) {
                 return Err(ErrorKind::ResizingTerminalFailure(String::from(
                     "Something went wrong when setting screen buffer size.",
                 )));
@@ -138,13 +142,13 @@ impl ITerminal for WinApiTerminal {
 
         let mut window = window.clone();
         // Preserve the position, but change the size.
-        window.bottom = window.top + height;
-        window.right = window.left + width;
+        window.bottom = window.top + height - 1;
+        window.right = window.left + width - 1;
         console.set_console_info(true, window)?;
 
         // If we resized the buffer, un-resize it.
         if resize_buffer {
-            if let Err(_) = screen_buffer.set_size(current_size.width, current_size.height) {
+            if let Err(_) = screen_buffer.set_size(current_size.width - 1, current_size.height - 1) {
                 return Err(ErrorKind::ResizingTerminalFailure(String::from(
                     "Something went wrong when setting screen buffer size.",
                 )));
@@ -280,9 +284,7 @@ fn clear(start_location: Coord, cells_to_write: u32, current_attribute: u16) -> 
 mod tests {
     use super::{ITerminal, WinApiTerminal};
 
-    // TODO - Test is ignored, because it returns wrong result (31 != 30)
     #[test]
-    #[ignore]
     fn test_resize_winapi() {
         let terminal = WinApiTerminal::new();
 
@@ -291,6 +293,7 @@ mod tests {
         terminal.set_size(30, 30).unwrap();
         assert_eq!((30, 30), terminal.size().unwrap());
 
+        // reset to previous size
         terminal.set_size(width, height).unwrap();
         assert_eq!((width, height), terminal.size().unwrap());
     }

--- a/crossterm_terminal/src/terminal/winapi_terminal.rs
+++ b/crossterm_terminal/src/terminal/winapi_terminal.rs
@@ -129,8 +129,8 @@ impl ITerminal for WinApiTerminal {
         }
 
         println!("{:?}", new_size);
-        println!("{:?}",current_size);
-        println!("{:?}",window);
+        println!("{:?}", current_size);
+        println!("{:?}", window);
 
         if resize_buffer {
             if let Err(_) = screen_buffer.set_size(new_size.width - 1, new_size.height - 1) {
@@ -148,7 +148,8 @@ impl ITerminal for WinApiTerminal {
 
         // If we resized the buffer, un-resize it.
         if resize_buffer {
-            if let Err(_) = screen_buffer.set_size(current_size.width - 1, current_size.height - 1) {
+            if let Err(_) = screen_buffer.set_size(current_size.width - 1, current_size.height - 1)
+            {
                 return Err(ErrorKind::ResizingTerminalFailure(String::from(
                     "Something went wrong when setting screen buffer size.",
                 )));

--- a/crossterm_terminal/src/terminal/winapi_terminal.rs
+++ b/crossterm_terminal/src/terminal/winapi_terminal.rs
@@ -128,10 +128,6 @@ impl ITerminal for WinApiTerminal {
             resize_buffer = true;
         }
 
-        println!("{:?}", new_size);
-        println!("{:?}", current_size);
-        println!("{:?}", window);
-
         if resize_buffer {
             if let Err(_) = screen_buffer.set_size(new_size.width - 1, new_size.height - 1) {
                 return Err(ErrorKind::ResizingTerminalFailure(String::from(


### PR DESCRIPTION
- Increased get terminal size by one (corrected [change](https://github.com/TimonPost/crossterm/commit/41de9a63a1a1ac768c225fa2328fdc2890f3171d#diff-f6a97d614303969c5f5116bdd1f0fac4L9))

- Decreased set terminal size windows by 1. Windows starts counting from 0, when setting the size to 5, 5 windows will see that as 6,6, therefore we need to subtract 1.

- removed ignores from test
