### PR TITLE
Gate crossterm_winapi with cfg(windows)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ script:
   - rustc --version
   - if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then cargo fmt --all -- --check; fi
   - cargo build
-  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then cargo test --all -- --nocapture --test-threads 1; else cargo test --all --exclude crossterm_winapi -- --nocapture --test-threads 1; fi
+  - cargo test --all -- --nocapture --test-threads 1
   - scripts/test-examples.sh

--- a/crossterm_winapi/Cargo.toml
+++ b/crossterm_winapi/Cargo.toml
@@ -13,3 +13,6 @@ edition = "2018"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version =  "0.3.7", features = ["winbase","consoleapi","processenv", "handleapi"] }
+
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"

--- a/crossterm_winapi/Cargo.toml
+++ b/crossterm_winapi/Cargo.toml
@@ -11,5 +11,5 @@ exclude = ["target", "Cargo.lock"]
 readme = "README.md"
 edition = "2018"
 
-[dependencies]
+[target.'cfg(windows)'.dependencies]
 winapi = { version =  "0.3.7", features = ["winbase","consoleapi","processenv", "handleapi"] }

--- a/crossterm_winapi/examples/cw_coloring_example.rs
+++ b/crossterm_winapi/examples/cw_coloring_example.rs
@@ -1,7 +1,10 @@
+#[cfg(windows)]
 use std::io::Result;
 
+#[cfg(windows)]
 use crossterm_winapi::{Console, ScreenBuffer};
 
+#[cfg(windows)]
 fn set_background_color() -> Result<()> {
     // background value
     const BLUE_BACKGROUND: u16 = 0x0010;
@@ -23,6 +26,7 @@ fn set_background_color() -> Result<()> {
     Ok(())
 }
 
+#[cfg(windows)]
 fn set_foreground_color() -> Result<()> {
     // background value
     const BLUE_FOREGROUND: u16 = 0x0001;
@@ -48,7 +52,13 @@ fn set_foreground_color() -> Result<()> {
     Ok(())
 }
 
+#[cfg(windows)]
 fn main() -> Result<()> {
     set_background_color()?;
     set_foreground_color()
+}
+
+#[cfg(not(windows))]
+fn main() {
+    println!("This example is for the Windows platform only.");
 }

--- a/crossterm_winapi/examples/cw_console.rs
+++ b/crossterm_winapi/examples/cw_console.rs
@@ -1,7 +1,10 @@
+#[cfg(windows)]
 use std::io::Result;
 
+#[cfg(windows)]
 use crossterm_winapi::ConsoleMode;
 
+#[cfg(windows)]
 fn change_console_mode() -> Result<()> {
     let console_mode = ConsoleMode::new()?;
 
@@ -12,6 +15,12 @@ fn change_console_mode() -> Result<()> {
     console_mode.set_mode(10)
 }
 
+#[cfg(windows)]
 fn main() -> Result<()> {
     change_console_mode()
+}
+
+#[cfg(not(windows))]
+fn main() {
+    println!("This example is for the Windows platform only.");
 }

--- a/crossterm_winapi/examples/cw_handle.rs
+++ b/crossterm_winapi/examples/cw_handle.rs
@@ -1,7 +1,10 @@
+#[cfg(windows)]
 use std::io::Result;
 
+#[cfg(windows)]
 use crossterm_winapi::{Handle, HandleType};
 
+#[cfg(windows)]
 #[allow(unused_variables)]
 fn main() -> Result<()> {
     // see the description of the types to see what they do.
@@ -19,4 +22,9 @@ fn main() -> Result<()> {
     let handle = Handle::from(handle); /* winapi::um::winnt::HANDLE */
 
     Ok(())
+}
+
+#[cfg(not(windows))]
+fn main() {
+    println!("This example is for the Windows platform only.");
 }

--- a/crossterm_winapi/examples/cw_screen_buffer.rs
+++ b/crossterm_winapi/examples/cw_screen_buffer.rs
@@ -1,9 +1,12 @@
 #![allow(dead_code)]
 
+#[cfg(windows)]
 use std::io::Result;
 
+#[cfg(windows)]
 use crossterm_winapi::ScreenBuffer;
 
+#[cfg(windows)]
 fn print_screen_buffer_information() -> Result<()> {
     let screen_buffer = ScreenBuffer::current()?;
 
@@ -18,6 +21,7 @@ fn print_screen_buffer_information() -> Result<()> {
     Ok(())
 }
 
+#[cfg(windows)]
 fn multiple_screen_buffers() -> Result<()> {
     // create new screen buffer
     let screen_buffer = ScreenBuffer::create();
@@ -26,6 +30,12 @@ fn multiple_screen_buffers() -> Result<()> {
     screen_buffer.show()
 }
 
+#[cfg(windows)]
 fn main() -> Result<()> {
     print_screen_buffer_information()
+}
+
+#[cfg(not(windows))]
+fn main() {
+    println!("This example is for the Windows platform only.");
 }

--- a/crossterm_winapi/src/lib.rs
+++ b/crossterm_winapi/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(windows)]
 #![deny(unused_imports)]
 
 pub use self::{


### PR DESCRIPTION
Same stuff as the [winapi-rs](https://github.com/retep998/winapi-rs) does:

* Dependencies are gated with `cfg(windows)`
* The whole library is gated with the `#![cfg(windows)]`
* Examples are gated with `#[cfg(windows)]` & `#[cfg(not(windows))]`
* Allows to use `cargo test --all` on all platforms
* Package metadata added to specify default documentation build target
  * Compare [winapi](https://docs.rs/winapi/0.3.8/winapi/) & [crossterm_winapi](https://docs.rs/crate/crossterm_winapi/0.1.5)

<img width="917" alt="Screenshot 2019-09-23 at 09 22 38" src="https://user-images.githubusercontent.com/1084172/65407739-c4c3ed00-dde3-11e9-8f2c-c54571f43f84.png">


Fixes #220 