### PR TITLE
feat: ANSI APC implementation as a new event type + it's parsing implementation

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -567,7 +567,7 @@ pub enum Event {
     Resize(u16, u16),
     /// Application Program Command sent by the terminal.
     /// Primarily used by the Kitty terminal for graphics commands.
-    ApplicationProgramCommand(String)
+    ApplicationProgramCommand(String),
 }
 
 impl Event {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -137,7 +137,7 @@ pub fn size() -> io::Result<(u16, u16)> {
     sys::size()
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WindowSize {
     pub rows: u16,
     pub columns: u16,


### PR DESCRIPTION
**What is this?**
This is an implementation for parsing ANSI APC (Application Program Control) sequences into a new event type. The event type in the `enum Event` is named for `ApplicationProgramControl` and holds a string. ANSI APC sequences have the form of: 
```
<ESC>_<STRING><ESC>\
```
The parsing method is implemented only for the parser-unix submodule as it's used only in the UNIX-sphere (see below).  

**Why?**
The Kitty terminal uses APC sequences to encode status responses for the transfer and display of image data to and by the terminal. Currently there are no other solutions for parsing APC sequences by the `crossterm` package and such APC sequences sent, e.g by the Kitty terminal, are represented as a sequence of key-presses; see #834.

The only possibility for the end-user to parse such APC sequences with the `crossterm` package is to write an additional parser on top of the produced `KeyEvent` sequence which is not optimal.

**Discussion**
- More suitable name for the event type?
- Creating a more general event type for unrecognized escape sequences as suggested by #834?
-  Isn't really a cross-platform feature as only the Kitty terminal currently uses APC