### PR TITLE
introduce `no-tty` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ serial_test = "3.0.0"
 temp-env = "0.3.6"
 tokio = { version = "1.44", features = ["full"] }
 russh = "0.53.0"
+rand_core = "0.6"
 anyhow="1"
 
 # Examples

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ derive-more = ["dep:derive_more"]
 #! ### Optional Features
 
 ## Enable non-psudo-terminal
-no-tty = ["dep:crossbeam-channel"]
+no-tty = ["dep:crossbeam-channel", "tokio"]
 
 ## Enables documentation for crate features.
 document-features = ["dep:document-features"]
@@ -64,13 +64,17 @@ document-features = { version = "0.2.11", optional = true }
 futures-core = { version = "0.3", optional = true, default-features = false }
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"], optional = true }
-crossbeam-channel = {version = "0.5",optional=true}
+crossbeam-channel = { version = "0.5", optional = true }
+tokio = { version = "1", optional = true, features = ["sync"] }
 
 
 # Windows dependencies
 [target.'cfg(windows)'.dependencies]
 crossterm_winapi = { version = "0.9.1", optional = true }
-winapi = { version = "0.3.9", optional = true, features = ["winuser", "winerror"] }
+winapi = { version = "0.3.9", optional = true, features = [
+  "winuser",
+  "winerror",
+] }
 
 # UNIX dependencies
 [target.'cfg(all(unix,not(feature="no-tty")))'.dependencies]
@@ -79,9 +83,15 @@ filedescriptor = { version = "0.8", optional = true }
 # compatibility.
 libc = { version = "0.2", default-features = false, optional = true }
 mio = { version = "1.0", features = ["os-poll"], optional = true }
-rustix = { version = "1", default-features = false, features = ["std", "stdio", "termios"] }
+rustix = { version = "1", default-features = false, features = [
+  "std",
+  "stdio",
+  "termios",
+] }
 signal-hook = { version = "0.3.17", optional = true }
-signal-hook-mio = { version = "0.2.4", features = ["support-v1_0"], optional = true }
+signal-hook-mio = { version = "0.2.4", features = [
+  "support-v1_0",
+], optional = true }
 
 [dev-dependencies]
 async-std = "1.13"
@@ -93,7 +103,7 @@ temp-env = "0.3.6"
 tokio = { version = "1.44", features = ["full"] }
 russh = "0.53.0"
 rand_core = "0.6"
-anyhow="1"
+anyhow = "1"
 
 # Examples
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ derive-more = ["dep:derive_more"]
 
 #! ### Optional Features
 
+## Enable non-psudo-terminal
+no-tty = ["dep:crossbeam-channel"]
+
 ## Enables documentation for crate features.
 document-features = ["dep:document-features"]
 
@@ -61,6 +64,8 @@ document-features = { version = "0.2.11", optional = true }
 futures-core = { version = "0.3", optional = true, default-features = false }
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"], optional = true }
+crossbeam-channel = {version = "0.5",optional=true}
+
 
 # Windows dependencies
 [target.'cfg(windows)'.dependencies]
@@ -68,7 +73,7 @@ crossterm_winapi = { version = "0.9.1", optional = true }
 winapi = { version = "0.3.9", optional = true, features = ["winuser", "winerror"] }
 
 # UNIX dependencies
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(all(unix,not(feature="no-tty")))'.dependencies]
 filedescriptor = { version = "0.8", optional = true }
 # Default to using rustix for UNIX systems, but provide an option to use libc for backwards
 # compatibility.
@@ -80,12 +85,14 @@ signal-hook-mio = { version = "0.2.4", features = ["support-v1_0"], optional = t
 
 [dev-dependencies]
 async-std = "1.13"
-futures = "0.3"
+futures = "0.3.31"
 futures-timer = "3.0"
 serde_json = "1.0"
 serial_test = "3.0.0"
 temp-env = "0.3.6"
 tokio = { version = "1.44", features = ["full"] }
+russh = "0.53.0"
+anyhow="1"
 
 # Examples
 [[example]]
@@ -119,6 +126,10 @@ required-features = ["events"]
 [[example]]
 name = "key-display"
 required-features = ["events"]
+
+[[example]]
+name = "ssh-service"
+required-features = ["no-tty"]
 
 [[example]]
 name = "copy-to-clipboard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ derive-more = ["dep:derive_more"]
 #! ### Optional Features
 
 ## Enable non-psudo-terminal
-no-tty = ["dep:tokio", "events"]
+no-tty = ["dep:tokio", "events", "bracketed-paste"]
 
 ## Enables documentation for crate features.
 document-features = ["dep:document-features"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ derive-more = ["dep:derive_more"]
 #! ### Optional Features
 
 ## Enable non-psudo-terminal
-no-tty = ["dep:crossbeam-channel", "tokio"]
+no-tty = ["dep:tokio", "events"]
 
 ## Enables documentation for crate features.
 document-features = ["dep:document-features"]
@@ -64,8 +64,7 @@ document-features = { version = "0.2.11", optional = true }
 futures-core = { version = "0.3", optional = true, default-features = false }
 parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"], optional = true }
-crossbeam-channel = { version = "0.5", optional = true }
-tokio = { version = "1", optional = true, features = ["sync"] }
+tokio = { version = "1", optional = true, features = ["sync", "time"] }
 
 
 # Windows dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ derive-more = ["dep:derive_more"]
 #! ### Optional Features
 
 ## Enable non-psudo-terminal
-no-tty = ["dep:tokio", "events", "bracketed-paste"]
+no-tty = ["dep:tokio", "dep:bytes", "events", "bracketed-paste"]
 
 ## Enables documentation for crate features.
 document-features = ["dep:document-features"]
@@ -59,6 +59,7 @@ osc52 = ["dep:base64"]
 [dependencies]
 base64 = { version = "0.22", optional = true }
 bitflags = { version = "2.9" }
+bytes = { version = "1", optional = true }
 derive_more = { version = "2.0.0", features = ["is_variant"], optional = true }
 document-features = { version = "0.2.11", optional = true }
 futures-core = { version = "0.3", optional = true, default-features = false }

--- a/examples/ssh-service.rs
+++ b/examples/ssh-service.rs
@@ -1,0 +1,328 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crossterm::event::{
+    poll, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+};
+use std::time::Duration;
+
+use crossbeam_channel::{unbounded, Receiver, Sender};
+use crossterm::event::NoTtyEvent;
+use crossterm::{
+    cursor::position,
+    event::{
+        read, DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
+        EnableFocusChange, EnableMouseCapture, Event, KeyCode,
+    },
+    execute, queue,
+    terminal::WindowSize,
+};
+use russh::keys::ssh_key::PublicKey;
+use russh::keys::PrivateKey;
+use russh::server::*;
+use russh::{Channel, ChannelId, Pty};
+use tokio::sync::Mutex;
+
+struct App {
+    pub pty: NoTtyEvent,
+    pub send: Sender<Vec<u8>>,
+    pub recv: Receiver<Vec<u8>>,
+}
+
+#[derive(Clone)]
+struct AppServer {
+    clients: Arc<Mutex<HashMap<usize, App>>>,
+    id: usize,
+}
+
+impl AppServer {
+    pub fn new() -> Self {
+        Self {
+            clients: Arc::new(Mutex::new(HashMap::new())),
+            id: 0,
+        }
+    }
+
+    pub async fn run(&mut self) -> Result<(), anyhow::Error> {
+        // NOTE: For test only
+        let encoded_private_key = r#"
+-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACCIZOukggdnRXIYg7MP8GcSYVGMWXSAxBuaTo5JrVEbrwAAAKC+kpPxvpKT
+8QAAAAtzc2gtZWQyNTUxOQAAACCIZOukggdnRXIYg7MP8GcSYVGMWXSAxBuaTo5JrVEbrw
+AAAEBY+ilXLu4O3XnxgKtZeZB592hGsWvIWQN9AF8Ee+cIGohk66SCB2dFchiDsw/wZxJh
+UYxZdIDEG5pOjkmtURuvAAAAGnJpY2tAbG9jYWxob3N0LmxvY2FsZG9tYWluAQID
+-----END OPENSSH PRIVATE KEY-----
+"#;
+        let private_key = encoded_private_key.parse::<PrivateKey>().unwrap();
+        let config = Config {
+            inactivity_timeout: Some(std::time::Duration::from_secs(3600)),
+            auth_rejection_time: std::time::Duration::from_secs(3),
+            auth_rejection_time_initial: Some(std::time::Duration::from_secs(0)),
+            keys: vec![private_key],
+            nodelay: true,
+            ..Default::default()
+        };
+
+        self.run_on_address(Arc::new(config), ("0.0.0.0", 2222))
+            .await?;
+        Ok(())
+    }
+}
+
+impl Server for AppServer {
+    type Handler = Self;
+    fn new_client(&mut self, _: Option<std::net::SocketAddr>) -> Self {
+        let s = self.clone();
+        self.id += 1;
+        s
+    }
+}
+
+impl Handler for AppServer {
+    type Error = russh::Error;
+
+    async fn channel_open_session(
+        &mut self,
+        _channel: Channel<Msg>,
+        _session: &mut Session,
+    ) -> Result<bool, Self::Error> {
+        let (app_send, term_recv) = unbounded();
+        let (psudo_tty, app_recv) = NoTtyEvent::new(term_recv);
+        let app = App {
+            pty: psudo_tty,
+            send: app_send,
+            recv: app_recv,
+        };
+
+        let mut clients = self.clients.lock().await;
+        clients.insert(self.id, app);
+
+        Ok(true)
+    }
+
+    async fn auth_publickey(&mut self, _: &str, _: &PublicKey) -> Result<Auth, Self::Error> {
+        Ok(Auth::Accept)
+    }
+
+    async fn data(
+        &mut self,
+        _channel: ChannelId,
+        data: &[u8],
+        _session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        let mut clients = self.clients.lock().await;
+        let app = clients.get_mut(&self.id).unwrap();
+        let _ = app.send.send(data.into()).unwrap();
+        if data == [3] {
+            return Err(russh::Error::Disconnect);
+        }
+
+        Ok(())
+    }
+
+    /// The client's window size has changed.
+    async fn window_change_request(
+        &mut self,
+        _channel: ChannelId,
+        col_width: u32,
+        row_height: u32,
+        pix_width: u32,
+        pix_height: u32,
+        _session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        let mut clients = self.clients.lock().await;
+        let app = clients.get_mut(&self.id).unwrap();
+        *app.pty.window_size.lock() = WindowSize {
+            rows: row_height as u16,
+            columns: col_width as u16,
+            width: pix_width as u16,
+            height: pix_height as u16,
+        };
+
+        let mut win_raw = Vec::from(b"\x1B[W");
+        let col = (col_width as u16).to_string();
+        let row = (row_height as u16).to_string();
+        win_raw.extend_from_slice(col.as_bytes());
+        win_raw.push(b';');
+        win_raw.extend_from_slice(row.as_bytes());
+        win_raw.push(b'R');
+        let _ = app.send.send(win_raw);
+
+        Ok(())
+    }
+
+    /// The client requests a pseudo-terminal with the given
+    /// specifications.
+    ///
+    /// NOTE: Success or failure should be communicated to the client by calling
+    /// `session.channel_success(channel)` or `session.channel_failure(channel)` respectively.
+    async fn pty_request(
+        &mut self,
+        channel: ChannelId,
+        _: &str,
+        col_width: u32,
+        row_height: u32,
+        pix_width: u32,
+        pix_height: u32,
+        _: &[(Pty, u32)],
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        let mut clients = self.clients.lock().await;
+        let app = clients.get_mut(&self.id).unwrap();
+
+        *app.pty.window_size.lock() = WindowSize {
+            rows: row_height as u16,
+            columns: col_width as u16,
+            width: pix_width as u16,
+            height: pix_height as u16,
+        };
+
+        session.channel_success(channel)?;
+
+        Ok(())
+    }
+    async fn shell_request(
+        &mut self,
+        channel: ChannelId,
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        let mut clients = self.clients.lock().await;
+        let app = clients.get_mut(&self.id).unwrap();
+        let pty = app.pty.clone();
+        let handle = session.handle();
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(5);
+        let tx2 = tx.clone();
+        const HELP: &str = "Blocking read()\r\n- Keyboard, mouse, focus and terminal resize events enabled\r\n- Hit \"c\" to print current cursor position\r\n- Use Esc to quit\r\n";
+        let _ = handle.data(channel, HELP.into()).await;
+        tokio::task::spawn_blocking(move || {
+            let supports_keyboard_enhancement = matches!(
+                crossterm::terminal::supports_keyboard_enhancement(&pty),
+                Ok(true)
+            );
+            let mut tx = SenderWriter(tx);
+
+            if supports_keyboard_enhancement {
+                let _ = queue!(
+                    tx,
+                    PushKeyboardEnhancementFlags(
+                        KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                            | KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES
+                            | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
+                            | KeyboardEnhancementFlags::REPORT_EVENT_TYPES
+                    )
+                );
+            }
+
+            let _ = execute!(
+                tx,
+                EnableBracketedPaste,
+                EnableFocusChange,
+                EnableMouseCapture,
+            );
+
+            loop {
+                // Blocking read
+                let event = match read(&pty) {
+                    Ok(e) => e,
+                    Err(_) => {
+                        continue;
+                    }
+                };
+
+                let data = format!("Event: {event:?}\r\n");
+                let _ = tx.0.blocking_send(data.into());
+
+                if event == Event::Key(KeyCode::Char('c').into()) {
+                    let data = format!("Cursor position: {:?}\r\n", position(&pty));
+                    let _ = tx.0.blocking_send(data.into());
+                }
+
+                if let Event::Resize(x, y) = event {
+                    let (original_size, new_size) = flush_resize_events(&pty, (x, y));
+                    let data = format!("Resize from: {original_size:?}, to: {new_size:?}\r\n");
+                    let _ = tx.0.blocking_send(data.into());
+                }
+
+                if event == Event::Key(KeyCode::Esc.into()) {
+                    break;
+                }
+            }
+            if supports_keyboard_enhancement {
+                let _ = queue!(tx, PopKeyboardEnhancementFlags);
+            }
+
+            let _ = execute!(
+                tx,
+                DisableBracketedPaste,
+                DisableFocusChange,
+                DisableMouseCapture
+            );
+        });
+        let r = app.recv.clone();
+        tokio::task::spawn_blocking(move || loop {
+            if let Ok(d) = r.recv() {
+                let _ = tx2.blocking_send(d);
+            } else {
+                break;
+            }
+        });
+        tokio::spawn(async move {
+            loop {
+                if let Some(data) = rx.recv().await {
+                    let _ = handle.data(channel, data.into()).await;
+                } else {
+                    let _ = handle.close(channel).await;
+                }
+            }
+        });
+        session.channel_success(channel)?;
+        Ok(())
+    }
+}
+
+// Resize events can occur in batches.
+// With a simple loop they can be flushed.
+// This function will keep the first and last resize event.
+fn flush_resize_events(event: &NoTtyEvent, first_resize: (u16, u16)) -> ((u16, u16), (u16, u16)) {
+    let mut last_resize = first_resize;
+    while let Ok(true) = poll(event, Duration::from_millis(50)) {
+        if let Ok(Event::Resize(x, y)) = read(event) {
+            last_resize = (x, y);
+        }
+    }
+
+    (first_resize, last_resize)
+}
+
+impl Drop for AppServer {
+    fn drop(&mut self) {
+        let id = self.id;
+        let clients = self.clients.clone();
+        tokio::spawn(async move {
+            let mut clients = clients.lock().await;
+            clients.remove(&id);
+        });
+    }
+}
+
+struct SenderWriter(tokio::sync::mpsc::Sender<Vec<u8>>);
+impl std::io::Write for SenderWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .blocking_send(buf.to_vec())
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        // mpsc is unbuffered; nothing to flush
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let mut server = AppServer::new();
+    server.run().await.expect("Failed running server");
+}

--- a/examples/ssh-service.rs
+++ b/examples/ssh-service.rs
@@ -16,10 +16,10 @@ use crossterm::{
     },
     terminal::WindowSize,
 };
-use tokio::sync::mpsc::{channel, Receiver, Sender};
 use russh::keys::ssh_key::PublicKey;
 use russh::server::*;
 use russh::{Channel, ChannelId, Pty};
+use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::Mutex;
 
 struct App {
@@ -279,7 +279,10 @@ impl Handler for AppServer {
 // Resize events can occur in batches.
 // With a simple loop they can be flushed.
 // This function will keep the first and last resize event.
-async fn flush_resize_events(event: &NoTtyEvent, first_resize: (u16, u16)) -> ((u16, u16), (u16, u16)) {
+async fn flush_resize_events(
+    event: &NoTtyEvent,
+    first_resize: (u16, u16),
+) -> ((u16, u16), (u16, u16)) {
     let mut last_resize = first_resize;
     while let Ok(true) = poll(event, Duration::from_millis(50)).await {
         if let Ok(Event::Resize(x, y)) = read(event).await {

--- a/examples/ssh-service.rs
+++ b/examples/ssh-service.rs
@@ -6,17 +6,17 @@ use crossterm::event::{
 };
 use std::time::Duration;
 
-use crossbeam_channel::{unbounded, Receiver, Sender};
 use crossterm::event::{NoTtyEvent, SenderWriter};
 use crossterm::{
+    async_execute, async_queue,
     cursor::position,
     event::{
         read, DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
         EnableFocusChange, EnableMouseCapture, Event, KeyCode,
     },
-    execute, queue,
     terminal::WindowSize,
 };
+use tokio::sync::mpsc::{channel, Receiver, Sender};
 use russh::keys::ssh_key::PublicKey;
 use russh::server::*;
 use russh::{Channel, ChannelId, Pty};
@@ -25,7 +25,7 @@ use tokio::sync::Mutex;
 struct App {
     pub pty: NoTtyEvent,
     pub send: Sender<Vec<u8>>,
-    pub recv: Receiver<Vec<u8>>,
+    pub recv: Option<Receiver<Vec<u8>>>,
 }
 
 #[derive(Clone)]
@@ -79,12 +79,12 @@ impl Handler for AppServer {
         _channel: Channel<Msg>,
         _session: &mut Session,
     ) -> Result<bool, Self::Error> {
-        let (app_send, term_recv) = unbounded();
+        let (app_send, term_recv) = channel::<Vec<u8>>(64);
         let (psudo_tty, app_recv) = NoTtyEvent::new(term_recv);
         let app = App {
             pty: psudo_tty,
             send: app_send,
-            recv: app_recv,
+            recv: Some(app_recv),
         };
 
         let mut clients = self.clients.lock().await;
@@ -105,7 +105,7 @@ impl Handler for AppServer {
     ) -> Result<(), Self::Error> {
         let mut clients = self.clients.lock().await;
         let app = clients.get_mut(&self.id).unwrap();
-        let _ = app.send.send(data.into()).unwrap();
+        let _ = app.send.send(data.into()).await;
         if data == [3] {
             return Err(russh::Error::Disconnect);
         }
@@ -139,7 +139,7 @@ impl Handler for AppServer {
         win_raw.push(b';');
         win_raw.extend_from_slice(row.as_bytes());
         win_raw.push(b'R');
-        let _ = app.send.send(win_raw);
+        let _ = app.send.send(win_raw).await;
 
         Ok(())
     }
@@ -188,35 +188,38 @@ impl Handler for AppServer {
         let tx3 = tx.clone();
         const HELP: &str = "Blocking read()\r\n- Keyboard, mouse, focus and terminal resize events enabled\r\n- Hit \"c\" to print current cursor position\r\n- Use Esc to quit\r\n";
         let _ = handle.data(channel, HELP.into()).await;
-        tokio::task::spawn_blocking(move || {
+        let app_recv_for_forward = app.recv.take().unwrap();
+        let pty2 = pty.clone();
+        let writer = SenderWriter::new(tx.clone());
+        tokio::spawn(async move {
             let supports_keyboard_enhancement = matches!(
-                crossterm::terminal::supports_keyboard_enhancement(&pty),
+                crossterm::terminal::supports_keyboard_enhancement(&pty2).await,
                 Ok(true)
             );
-            let mut tx = SenderWriter::new(tx);
 
             if supports_keyboard_enhancement {
-                let _ = queue!(
-                    tx,
+                let _ = async_queue!(
+                    &writer,
                     PushKeyboardEnhancementFlags(
                         KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
                             | KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES
                             | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
                             | KeyboardEnhancementFlags::REPORT_EVENT_TYPES
                     )
-                );
+                )
+                .await;
             }
 
-            let _ = execute!(
-                tx,
+            let _ = async_execute!(
+                &writer,
                 EnableBracketedPaste,
                 EnableFocusChange,
                 EnableMouseCapture,
-            );
+            )
+            .await;
 
             loop {
-                // Blocking read
-                let event = match read(&pty) {
+                let event = match read(&pty2).await {
                     Ok(e) => e,
                     Err(_) => {
                         continue;
@@ -224,17 +227,17 @@ impl Handler for AppServer {
                 };
 
                 let data = format!("Event: {event:?}\r\n");
-                let _ = tx3.blocking_send(data.into());
+                let _ = tx3.send(data.into()).await;
 
                 if event == Event::Key(KeyCode::Char('c').into()) {
-                    let data = format!("Cursor position: {:?}\r\n", position(&pty));
-                    let _ = tx3.blocking_send(data.into());
+                    let data = format!("Cursor position: {:?}\r\n", position(&pty2).await);
+                    let _ = tx3.send(data.into()).await;
                 }
 
                 if let Event::Resize(x, y) = event {
-                    let (original_size, new_size) = flush_resize_events(&pty, (x, y));
+                    let (original_size, new_size) = flush_resize_events(&pty2, (x, y)).await;
                     let data = format!("Resize from: {original_size:?}, to: {new_size:?}\r\n");
-                    let _ = tx3.blocking_send(data.into());
+                    let _ = tx3.send(data.into()).await;
                 }
 
                 if event == Event::Key(KeyCode::Esc.into()) {
@@ -242,22 +245,21 @@ impl Handler for AppServer {
                 }
             }
             if supports_keyboard_enhancement {
-                let _ = queue!(tx, PopKeyboardEnhancementFlags);
+                let _ = async_queue!(&writer, PopKeyboardEnhancementFlags).await;
             }
 
-            let _ = execute!(
-                tx,
+            let _ = async_execute!(
+                &writer,
                 DisableBracketedPaste,
                 DisableFocusChange,
                 DisableMouseCapture
-            );
+            )
+            .await;
         });
-        let r = app.recv.clone();
-        tokio::task::spawn_blocking(move || loop {
-            if let Ok(d) = r.recv() {
-                let _ = tx2.blocking_send(d);
-            } else {
-                break;
+        let mut r = app_recv_for_forward;
+        tokio::spawn(async move {
+            while let Some(d) = r.recv().await {
+                let _ = tx2.send(d).await;
             }
         });
         tokio::spawn(async move {
@@ -277,10 +279,10 @@ impl Handler for AppServer {
 // Resize events can occur in batches.
 // With a simple loop they can be flushed.
 // This function will keep the first and last resize event.
-fn flush_resize_events(event: &NoTtyEvent, first_resize: (u16, u16)) -> ((u16, u16), (u16, u16)) {
+async fn flush_resize_events(event: &NoTtyEvent, first_resize: (u16, u16)) -> ((u16, u16), (u16, u16)) {
     let mut last_resize = first_resize;
-    while let Ok(true) = poll(event, Duration::from_millis(50)) {
-        if let Ok(Event::Resize(x, y)) = read(event) {
+    while let Ok(true) = poll(event, Duration::from_millis(50)).await {
+        if let Ok(Event::Resize(x, y)) = read(event).await {
             last_resize = (x, y);
         }
     }

--- a/examples/ssh-service.rs
+++ b/examples/ssh-service.rs
@@ -6,6 +6,7 @@ use crossterm::event::{
 };
 use std::time::Duration;
 
+use bytes::Bytes;
 use crossterm::event::{NoTtyEvent, SenderWriter};
 use crossterm::{
     async_execute, async_queue,
@@ -24,8 +25,8 @@ use tokio::sync::Mutex;
 
 struct App {
     pub pty: NoTtyEvent,
-    pub send: Sender<Vec<u8>>,
-    pub recv: Option<Receiver<Vec<u8>>>,
+    pub send: Sender<Bytes>,
+    pub recv: Option<Receiver<Bytes>>,
 }
 
 #[derive(Clone)]
@@ -79,7 +80,7 @@ impl Handler for AppServer {
         _channel: Channel<Msg>,
         _session: &mut Session,
     ) -> Result<bool, Self::Error> {
-        let (app_send, term_recv) = channel::<Vec<u8>>(64);
+        let (app_send, term_recv) = channel::<Bytes>(64);
         let (psudo_tty, app_recv) = NoTtyEvent::new(term_recv);
         let app = App {
             pty: psudo_tty,
@@ -105,7 +106,7 @@ impl Handler for AppServer {
     ) -> Result<(), Self::Error> {
         let mut clients = self.clients.lock().await;
         let app = clients.get_mut(&self.id).unwrap();
-        let _ = app.send.send(data.into()).await;
+        let _ = app.send.send(Bytes::copy_from_slice(data)).await;
         if data == [3] {
             return Err(russh::Error::Disconnect);
         }
@@ -139,7 +140,7 @@ impl Handler for AppServer {
         win_raw.push(b';');
         win_raw.extend_from_slice(row.as_bytes());
         win_raw.push(b'R');
-        let _ = app.send.send(win_raw).await;
+        let _ = app.send.send(win_raw.into()).await;
 
         Ok(())
     }
@@ -183,7 +184,7 @@ impl Handler for AppServer {
         let app = clients.get_mut(&self.id).unwrap();
         let pty = app.pty.clone();
         let handle = session.handle();
-        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(5);
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<Bytes>(5);
         let tx2 = tx.clone();
         let tx3 = tx.clone();
         const HELP: &str = "Blocking read()\r\n- Keyboard, mouse, focus and terminal resize events enabled\r\n- Hit \"c\" to print current cursor position\r\n- Use Esc to quit\r\n";
@@ -265,7 +266,7 @@ impl Handler for AppServer {
         tokio::spawn(async move {
             loop {
                 if let Some(data) = rx.recv().await {
-                    let _ = handle.data(channel, data.into()).await;
+                    let _ = handle.data(channel, data.to_vec().into()).await;
                 } else {
                     let _ = handle.close(channel).await;
                 }

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -160,6 +160,7 @@ impl<T: AsRef<[u8]>> Command for CopyToClipboard<T> {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         use std::io;
 

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -65,6 +65,7 @@ impl Command for MoveTo {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         sys::move_to(self.0, self.1)
     }
@@ -87,6 +88,7 @@ impl Command for MoveToNextLine {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         if self.0 != 0 {
             sys::move_to_next_line(self.0)?;
@@ -112,6 +114,7 @@ impl Command for MoveToPreviousLine {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         if self.0 != 0 {
             sys::move_to_previous_line(self.0)?;
@@ -135,6 +138,7 @@ impl Command for MoveToColumn {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         sys::move_to_column(self.0)
     }
@@ -155,6 +159,7 @@ impl Command for MoveToRow {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         sys::move_to_row(self.0)
     }
@@ -176,6 +181,7 @@ impl Command for MoveUp {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         sys::move_up(self.0)
     }
@@ -197,6 +203,7 @@ impl Command for MoveRight {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         sys::move_right(self.0)
     }
@@ -218,6 +225,7 @@ impl Command for MoveDown {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         sys::move_down(self.0)
     }
@@ -239,6 +247,7 @@ impl Command for MoveLeft {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         sys::move_left(self.0)
     }
@@ -261,6 +270,7 @@ impl Command for SavePosition {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         sys::save_position()
     }
@@ -283,6 +293,7 @@ impl Command for RestorePosition {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         sys::restore_position()
     }
@@ -302,6 +313,7 @@ impl Command for Hide {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         sys::show_cursor(false)
     }
@@ -321,6 +333,7 @@ impl Command for Show {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         sys::show_cursor(true)
     }
@@ -340,6 +353,7 @@ impl Command for EnableBlinking {
         f.write_str(csi!("?12h"))
     }
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         Ok(())
     }
@@ -359,6 +373,7 @@ impl Command for DisableBlinking {
         f.write_str(csi!("?12l"))
     }
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         Ok(())
     }
@@ -402,6 +417,7 @@ impl Command for SetCursorStyle {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         Ok(())
     }
@@ -427,10 +443,13 @@ impl_display!(for SetCursorStyle);
 #[cfg(test)]
 #[cfg(feature = "events")]
 mod tests {
+    #[cfg(not(feature = "no-tty"))]
     use std::io::{self, stdout};
 
+    #[cfg(not(feature = "no-tty"))]
     use crate::execute;
 
+    #[cfg(not(feature = "no-tty"))]
     use super::{
         sys::position, MoveDown, MoveLeft, MoveRight, MoveTo, MoveUp, RestorePosition, SavePosition,
     };
@@ -438,6 +457,7 @@ mod tests {
     // Test is disabled, because it's failing on Travis
     #[test]
     #[ignore]
+    #[cfg(not(feature = "no-tty"))]
     fn test_move_to() {
         let (saved_x, saved_y) = position().unwrap();
 
@@ -451,6 +471,7 @@ mod tests {
     // Test is disabled, because it's failing on Travis
     #[test]
     #[ignore]
+    #[cfg(not(feature = "no-tty"))]
     fn test_move_right() {
         let (saved_x, saved_y) = position().unwrap();
         execute!(io::stdout(), MoveRight(1)).unwrap();
@@ -460,6 +481,7 @@ mod tests {
     // Test is disabled, because it's failing on Travis
     #[test]
     #[ignore]
+    #[cfg(not(feature = "no-tty"))]
     fn test_move_left() {
         execute!(stdout(), MoveTo(2, 0), MoveLeft(2)).unwrap();
         assert_eq!(position().unwrap(), (0, 0));
@@ -468,6 +490,7 @@ mod tests {
     // Test is disabled, because it's failing on Travis
     #[test]
     #[ignore]
+    #[cfg(not(feature = "no-tty"))]
     fn test_move_up() {
         execute!(stdout(), MoveTo(0, 2), MoveUp(2)).unwrap();
         assert_eq!(position().unwrap(), (0, 0));
@@ -476,6 +499,7 @@ mod tests {
     // Test is disabled, because it's failing on Travis
     #[test]
     #[ignore]
+    #[cfg(not(feature = "no-tty"))]
     fn test_move_down() {
         execute!(stdout(), MoveTo(0, 0), MoveDown(2)).unwrap();
 
@@ -485,6 +509,7 @@ mod tests {
     // Test is disabled, because it's failing on Travis
     #[test]
     #[ignore]
+    #[cfg(not(feature = "no-tty"))]
     fn test_save_restore_position() {
         let (saved_x, saved_y) = position().unwrap();
 

--- a/src/cursor/sys.rs
+++ b/src/cursor/sys.rs
@@ -1,20 +1,34 @@
 //! This module provides platform related functions.
 
 #[cfg(unix)]
+#[cfg(feature = "no-tty")]
+#[cfg(feature = "events")]
+pub use self::no_tty::position;
+#[cfg(unix)]
+#[cfg(not(feature = "no-tty"))]
 #[cfg(feature = "events")]
 pub use self::unix::position;
 #[cfg(windows)]
+#[cfg(not(feature = "no-tty"))]
 #[cfg(feature = "events")]
 pub use self::windows::position;
 #[cfg(windows)]
+#[cfg(not(feature = "no-tty"))]
 pub(crate) use self::windows::{
     move_down, move_left, move_right, move_to, move_to_column, move_to_next_line,
     move_to_previous_line, move_to_row, move_up, restore_position, save_position, show_cursor,
 };
 
 #[cfg(windows)]
+#[cfg(not(feature = "no-tty"))]
 pub(crate) mod windows;
 
 #[cfg(unix)]
+#[cfg(not(feature = "no-tty"))]
 #[cfg(feature = "events")]
 pub(crate) mod unix;
+
+#[cfg(unix)]
+#[cfg(feature = "no-tty")]
+#[cfg(feature = "events")]
+pub(crate) mod no_tty;

--- a/src/cursor/sys/no_tty.rs
+++ b/src/cursor/sys/no_tty.rs
@@ -1,0 +1,39 @@
+use std::{
+    io::{self, Error, ErrorKind},
+    time::Duration,
+};
+
+use crate::event::{
+    filter::CursorPositionFilter, internal::InternalEvent, internal_no_tty::NoTtyEvent,
+};
+
+/// Returns the cursor position (column, row).
+///
+/// The top left cell is represented as `(0, 0)`.
+///
+/// On unix systems, this function will block and possibly time out while
+/// [`crossterm::event::read`](crate::event::read) or [`crossterm::event::poll`](crate::event::poll) are being called.
+pub fn position(event: &NoTtyEvent) -> io::Result<(u16, u16)> {
+    // Use `ESC [ 6 n` to and retrieve the cursor position.
+    event
+        .send
+        .send_timeout(b"\x1B[6n".into(), Duration::from_secs(1))
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+    loop {
+        match event.poll(Some(Duration::from_millis(2000)), &CursorPositionFilter) {
+            Ok(true) => {
+                if let Ok(InternalEvent::CursorPosition(x, y)) = event.read(&CursorPositionFilter) {
+                    return Ok((x, y));
+                }
+            }
+            Ok(false) => {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    "The cursor position could not be read within a normal duration",
+                ));
+            }
+            Err(_) => {}
+        }
+    }
+}

--- a/src/cursor/sys/no_tty.rs
+++ b/src/cursor/sys/no_tty.rs
@@ -7,6 +7,8 @@ use crate::event::{
     filter::CursorPositionFilter, internal::InternalEvent, internal_no_tty::NoTtyEvent,
 };
 
+use bytes::Bytes;
+
 /// Returns the cursor position (column, row).
 ///
 /// The top left cell is represented as `(0, 0)`.
@@ -18,7 +20,7 @@ pub async fn position(event: &NoTtyEvent) -> io::Result<(u16, u16)> {
     // Use `ESC [ 6 n` to request the cursor position.
     event
         .send
-        .send_timeout(b"\x1B[6n".into(), Duration::from_secs(1))
+        .send_timeout(Bytes::from_static(b"\x1B[6n"), Duration::from_secs(1))
         .await
         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 

--- a/src/cursor/sys/no_tty.rs
+++ b/src/cursor/sys/no_tty.rs
@@ -7,24 +7,30 @@ use crate::event::{
     filter::CursorPositionFilter, internal::InternalEvent, internal_no_tty::NoTtyEvent,
 };
 
-use crossbeam_channel::RecvTimeoutError;
 /// Returns the cursor position (column, row).
 ///
 /// The top left cell is represented as `(0, 0)`.
 ///
-/// On unix systems, this function will block and possibly time out while
-/// [`crossterm::event::read`](crate::event::read) or [`crossterm::event::poll`](crate::event::poll) are being called.
-pub fn position(event: &NoTtyEvent) -> io::Result<(u16, u16)> {
-    // Use `ESC [ 6 n` to and retrieve the cursor position.
+/// This sends a cursor-position query out the event handle's query channel and awaits
+/// the response. It returns an error with kind [`io::ErrorKind::BrokenPipe`] if the
+/// input channel disconnects while waiting.
+pub async fn position(event: &NoTtyEvent) -> io::Result<(u16, u16)> {
+    // Use `ESC [ 6 n` to request the cursor position.
     event
         .send
         .send_timeout(b"\x1B[6n".into(), Duration::from_secs(1))
+        .await
         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
     loop {
-        match event.poll(Some(Duration::from_millis(2000)), &CursorPositionFilter) {
+        match event
+            .poll(Some(Duration::from_millis(2000)), &CursorPositionFilter)
+            .await
+        {
             Ok(true) => {
-                if let Ok(InternalEvent::CursorPosition(x, y)) = event.read(&CursorPositionFilter) {
+                if let Ok(InternalEvent::CursorPosition(x, y)) =
+                    event.read(&CursorPositionFilter).await
+                {
                     return Ok((x, y));
                 }
             }
@@ -34,14 +40,9 @@ pub fn position(event: &NoTtyEvent) -> io::Result<(u16, u16)> {
                     "The cursor position could not be read within a normal duration",
                 ));
             }
-            Err(e) if e.kind() == io::ErrorKind::Other => {
-                if Some(RecvTimeoutError::Disconnected)
-                    == e.get_ref()
-                        .and_then(|src| src.downcast_ref::<RecvTimeoutError>())
-                        .copied()
-                {
-                    return Err(e);
-                }
+            // The input channel disconnected; propagate so the caller can stop.
+            Err(e) if e.kind() == io::ErrorKind::BrokenPipe => {
+                return Err(e);
             }
             Err(_) => {}
         }

--- a/src/event.rs
+++ b/src/event.rs
@@ -133,7 +133,7 @@ pub(crate) mod timeout;
 pub mod internal_no_tty;
 #[cfg(unix)]
 #[cfg(feature = "no-tty")]
-pub use internal_no_tty::NoTtyEvent;
+pub use internal_no_tty::{NoTtyEvent, SenderWriter};
 
 #[cfg(feature = "derive-more")]
 use derive_more::derive::IsVariant;

--- a/src/event.rs
+++ b/src/event.rs
@@ -123,13 +123,22 @@ pub(crate) mod internal;
 pub(crate) mod read;
 pub(crate) mod source;
 #[cfg(feature = "event-stream")]
+#[cfg(not(feature = "no-tty"))]
 pub(crate) mod stream;
 pub(crate) mod sys;
 pub(crate) mod timeout;
 
+#[cfg(unix)]
+#[cfg(feature = "no-tty")]
+pub mod internal_no_tty;
+#[cfg(unix)]
+#[cfg(feature = "no-tty")]
+pub use internal_no_tty::NoTtyEvent;
+
 #[cfg(feature = "derive-more")]
 use derive_more::derive::IsVariant;
 #[cfg(feature = "event-stream")]
+#[cfg(not(feature = "no-tty"))]
 pub use stream::EventStream;
 
 use crate::{
@@ -182,8 +191,15 @@ use std::hash::{Hash, Hasher};
 ///     poll(Duration::from_millis(100))
 /// }
 /// ```
+#[cfg(not(feature = "no-tty"))]
 pub fn poll(timeout: Duration) -> std::io::Result<bool> {
     internal::poll(Some(timeout), &EventFilter)
+}
+
+#[cfg(unix)]
+#[cfg(feature = "no-tty")]
+pub fn poll(event: &NoTtyEvent, timeout: Duration) -> std::io::Result<bool> {
+    event.poll(Some(timeout), &EventFilter)
 }
 
 /// Reads a single [`Event`](enum.Event.html).
@@ -227,10 +243,20 @@ pub fn poll(timeout: Duration) -> std::io::Result<bool> {
 ///     }
 /// }
 /// ```
+#[cfg(not(feature = "no-tty"))]
 pub fn read() -> std::io::Result<Event> {
     match internal::read(&EventFilter)? {
         InternalEvent::Event(event) => Ok(event),
         #[cfg(unix)]
+        _ => unreachable!(),
+    }
+}
+
+#[cfg(unix)]
+#[cfg(feature = "no-tty")]
+pub fn read(event: &NoTtyEvent) -> std::io::Result<Event> {
+    match event.read(&EventFilter)? {
+        InternalEvent::Event(event) => Ok(event),
         _ => unreachable!(),
     }
 }
@@ -256,11 +282,22 @@ pub fn read() -> std::io::Result<Event> {
 ///     }
 /// }
 /// ```
+#[cfg(not(feature = "no-tty"))]
 pub fn try_read() -> Option<Event> {
     match internal::try_read(&EventFilter) {
         Some(InternalEvent::Event(event)) => Some(event),
         None => None,
         #[cfg(unix)]
+        _ => unreachable!(),
+    }
+}
+
+#[cfg(unix)]
+#[cfg(feature = "no-tty")]
+pub fn try_read(event: &NoTtyEvent) -> Option<Event> {
+    match event.try_read(&EventFilter) {
+        Some(InternalEvent::Event(event)) => Some(event),
+        None => None,
         _ => unreachable!(),
     }
 }
@@ -319,11 +356,13 @@ impl Command for EnableMouseCapture {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         sys::windows::enable_mouse_capture()
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn is_ansi_code_supported(&self) -> bool {
         false
     }
@@ -348,11 +387,13 @@ impl Command for DisableMouseCapture {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         sys::windows::disable_mouse_capture()
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn is_ansi_code_supported(&self) -> bool {
         false
     }
@@ -372,6 +413,7 @@ impl Command for EnableFocusChange {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         // Focus events are always enabled on Windows
         Ok(())
@@ -388,6 +430,7 @@ impl Command for DisableFocusChange {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         // Focus events can't be disabled on Windows
         Ok(())
@@ -411,6 +454,7 @@ impl Command for EnableBracketedPaste {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         Err(std::io::Error::new(
             std::io::ErrorKind::Unsupported,
@@ -431,6 +475,7 @@ impl Command for DisableBracketedPaste {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         Ok(())
     }
@@ -482,6 +527,7 @@ impl Command for PushKeyboardEnhancementFlags {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         use std::io;
 
@@ -492,6 +538,7 @@ impl Command for PushKeyboardEnhancementFlags {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn is_ansi_code_supported(&self) -> bool {
         false
     }
@@ -511,6 +558,7 @@ impl Command for PopKeyboardEnhancementFlags {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         use std::io;
 
@@ -521,6 +569,7 @@ impl Command for PopKeyboardEnhancementFlags {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn is_ansi_code_supported(&self) -> bool {
         false
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -198,8 +198,8 @@ pub fn poll(timeout: Duration) -> std::io::Result<bool> {
 
 #[cfg(unix)]
 #[cfg(feature = "no-tty")]
-pub fn poll(event: &NoTtyEvent, timeout: Duration) -> std::io::Result<bool> {
-    event.poll(Some(timeout), &EventFilter)
+pub async fn poll(event: &NoTtyEvent, timeout: Duration) -> std::io::Result<bool> {
+    event.poll(Some(timeout), &EventFilter).await
 }
 
 /// Reads a single [`Event`](enum.Event.html).
@@ -254,8 +254,8 @@ pub fn read() -> std::io::Result<Event> {
 
 #[cfg(unix)]
 #[cfg(feature = "no-tty")]
-pub fn read(event: &NoTtyEvent) -> std::io::Result<Event> {
-    match event.read(&EventFilter)? {
+pub async fn read(event: &NoTtyEvent) -> std::io::Result<Event> {
+    match event.read(&EventFilter).await? {
         InternalEvent::Event(event) => Ok(event),
         _ => unreachable!(),
     }
@@ -294,8 +294,8 @@ pub fn try_read() -> Option<Event> {
 
 #[cfg(unix)]
 #[cfg(feature = "no-tty")]
-pub fn try_read(event: &NoTtyEvent) -> Option<Event> {
-    match event.try_read(&EventFilter) {
+pub async fn try_read(event: &NoTtyEvent) -> Option<Event> {
+    match event.try_read(&EventFilter).await {
         Some(InternalEvent::Event(event)) => Some(event),
         None => None,
         _ => unreachable!(),

--- a/src/event/filter.rs
+++ b/src/event/filter.rs
@@ -56,6 +56,7 @@ impl Filter for EventFilter {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn eval(&self, _: &InternalEvent) -> bool {
         true
     }

--- a/src/event/internal.rs
+++ b/src/event/internal.rs
@@ -1,21 +1,28 @@
+#[cfg(not(feature = "no-tty"))]
 use std::time::Duration;
 
+#[cfg(not(feature = "no-tty"))]
 use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
 
+use crate::event::Event;
 #[cfg(unix)]
 use crate::event::KeyboardEnhancementFlags;
-use crate::event::{filter::Filter, read::InternalEventReader, timeout::PollTimeout, Event};
+#[cfg(not(feature = "no-tty"))]
+use crate::event::{filter::Filter, read::InternalEventReader, timeout::PollTimeout};
 
 /// Static instance of `InternalEventReader`.
 /// This needs to be static because there can be one event reader.
+#[cfg(not(feature = "no-tty"))]
 static EVENT_READER: Mutex<Option<InternalEventReader>> = parking_lot::const_mutex(None);
 
+#[cfg(not(feature = "no-tty"))]
 pub(crate) fn lock_event_reader() -> MappedMutexGuard<'static, InternalEventReader> {
     MutexGuard::map(EVENT_READER.lock(), |reader| {
         reader.get_or_insert_with(InternalEventReader::default)
     })
 }
 
+#[cfg(not(feature = "no-tty"))]
 fn try_lock_event_reader_for(
     duration: Duration,
 ) -> Option<MappedMutexGuard<'static, InternalEventReader>> {
@@ -26,6 +33,7 @@ fn try_lock_event_reader_for(
 }
 
 /// Polls to check if there are any `InternalEvent`s that can be read within the given duration.
+#[cfg(not(feature = "no-tty"))]
 pub(crate) fn poll<F>(timeout: Option<Duration>, filter: &F) -> std::io::Result<bool>
 where
     F: Filter,
@@ -44,6 +52,7 @@ where
 }
 
 /// Reads a single `InternalEvent`.
+#[cfg(not(feature = "no-tty"))]
 pub(crate) fn read<F>(filter: &F) -> std::io::Result<InternalEvent>
 where
     F: Filter,
@@ -53,6 +62,7 @@ where
 }
 
 /// Reads a single `InternalEvent`. Non-blocking.
+#[cfg(not(feature = "no-tty"))]
 pub(crate) fn try_read<F>(filter: &F) -> Option<InternalEvent>
 where
     F: Filter,

--- a/src/event/internal_no_tty.rs
+++ b/src/event/internal_no_tty.rs
@@ -1,0 +1,74 @@
+use super::internal::InternalEvent;
+use crate::event::source::no_tty::NoTtyInternalEventSource;
+use crate::event::source::EventSource;
+use crate::event::{filter::Filter, read::InternalEventReader, timeout::PollTimeout};
+use crate::terminal::WindowSize;
+use crossbeam_channel::{bounded, Receiver, Sender};
+use parking_lot::Mutex;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[derive(Clone)]
+pub struct NoTtyEvent {
+    pub(crate) send: Sender<Vec<u8>>,
+    pub window_size: Arc<Mutex<WindowSize>>,
+    inner: Arc<Mutex<InternalEventReader>>,
+}
+
+impl NoTtyEvent {
+    pub fn new(recv: Receiver<Vec<u8>>) -> (Self, Receiver<Vec<u8>>) {
+        let (s, r) = bounded(0);
+        let source = NoTtyInternalEventSource::new(recv);
+        let source = source.ok().map(|x| Box::new(x) as Box<dyn EventSource>);
+        let event = InternalEventReader::default().with_source(source);
+
+        (
+            Self {
+                send: s,
+                window_size: Arc::new(Mutex::new(WindowSize {
+                    rows: 0,
+                    columns: 0,
+                    width: 0,
+                    height: 0,
+                })),
+                inner: Arc::new(Mutex::new(event)),
+            },
+            r,
+        )
+    }
+    /// Polls to check if there are any `InternalEvent`s that can be read within the given duration.
+    pub(crate) fn poll<F>(&self, timeout: Option<Duration>, filter: &F) -> std::io::Result<bool>
+    where
+        F: Filter,
+    {
+        let (mut reader, timeout) = if let Some(timeout) = timeout {
+            let poll_timeout = PollTimeout::new(Some(timeout));
+            if let Some(reader) = self.inner.try_lock_for(timeout) {
+                (reader, poll_timeout.leftover())
+            } else {
+                return Ok(false);
+            }
+        } else {
+            (self.inner.lock(), None)
+        };
+        reader.poll(timeout, filter)
+    }
+
+    /// Reads a single `InternalEvent`.
+    pub(crate) fn read<F>(&self, filter: &F) -> std::io::Result<InternalEvent>
+    where
+        F: Filter,
+    {
+        let mut reader = self.inner.lock();
+        reader.read(filter)
+    }
+
+    /// Reads a single `InternalEvent`. Non-blocking.
+    pub(crate) fn try_read<F>(&self, filter: &F) -> Option<InternalEvent>
+    where
+        F: Filter,
+    {
+        let mut reader = self.inner.lock();
+        reader.try_read(filter)
+    }
+}

--- a/src/event/internal_no_tty.rs
+++ b/src/event/internal_no_tty.rs
@@ -102,6 +102,12 @@ impl SenderWriter {
         Self(sender)
     }
 
+    pub fn blocking_write_all(&self, buf: &[u8]) -> std::io::Result<()> {
+        self.0
+            .blocking_send(Bytes::copy_from_slice(buf))
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::BrokenPipe, e))
+    }
+
     /// Sends the given bytes over the channel, awaiting capacity.
     pub async fn write_all(&self, buf: &[u8]) -> std::io::Result<()> {
         self.0

--- a/src/event/internal_no_tty.rs
+++ b/src/event/internal_no_tty.rs
@@ -109,3 +109,27 @@ impl SenderWriter {
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::BrokenPipe, e))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::NoTtyEvent;
+    use crate::event::{read, Event, KeyCode, KeyModifiers};
+
+    #[tokio::test]
+    async fn read_parses_byte_fed_through_input_channel() {
+        // Input channel: host -> crossterm parser.
+        let (input_tx, input_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (pty, _query_rx) = NoTtyEvent::new(input_rx);
+
+        // Feed a plain 'a' keystroke.
+        input_tx.send(b"a".to_vec()).await.unwrap();
+
+        let event = read(&pty).await.unwrap();
+        assert_eq!(event, Event::Key(KeyCode::Char('a').into()));
+
+        // Keep the modifiers assertion explicit so the test documents intent.
+        if let Event::Key(key) = event {
+            assert_eq!(key.modifiers, KeyModifiers::NONE);
+        }
+    }
+}

--- a/src/event/internal_no_tty.rs
+++ b/src/event/internal_no_tty.rs
@@ -2,6 +2,7 @@ use super::internal::InternalEvent;
 use crate::event::source::no_tty::NoTtyInternalEventSource;
 use crate::event::{filter::Filter, read::InternalEventReader};
 use crate::terminal::WindowSize;
+use bytes::Bytes;
 use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
@@ -10,7 +11,7 @@ use tokio::sync::Mutex as AsyncMutex;
 
 #[derive(Clone)]
 pub struct NoTtyEvent {
-    pub(crate) send: Sender<Vec<u8>>,
+    pub(crate) send: Sender<Bytes>,
     pub window_size: Arc<Mutex<WindowSize>>,
     inner: Arc<AsyncMutex<InternalEventReader>>,
 }
@@ -21,7 +22,7 @@ impl NoTtyEvent {
     /// `recv` is the channel that carries raw input bytes (e.g. from an SSH client) into
     /// crossterm's parser. The returned [`Receiver`] carries crossterm's outgoing query
     /// escape sequences (cursor position, keyboard enhancement) back to the host.
-    pub fn new(recv: Receiver<Vec<u8>>) -> (Self, Receiver<Vec<u8>>) {
+    pub fn new(recv: Receiver<Bytes>) -> (Self, Receiver<Bytes>) {
         let (s, r) = channel(16);
         let source = NoTtyInternalEventSource::new(recv);
         let source = source.ok().map(Box::new);
@@ -94,17 +95,17 @@ impl NoTtyEvent {
 /// An async writer over an mpsc channel, used to forward crossterm command output
 /// (ANSI escape sequences) to the host that owns the receiving end.
 #[derive(Clone)]
-pub struct SenderWriter(tokio::sync::mpsc::Sender<Vec<u8>>);
+pub struct SenderWriter(tokio::sync::mpsc::Sender<Bytes>);
 
 impl SenderWriter {
-    pub fn new(sender: tokio::sync::mpsc::Sender<Vec<u8>>) -> Self {
+    pub fn new(sender: tokio::sync::mpsc::Sender<Bytes>) -> Self {
         Self(sender)
     }
 
     /// Sends the given bytes over the channel, awaiting capacity.
     pub async fn write_all(&self, buf: &[u8]) -> std::io::Result<()> {
         self.0
-            .send(buf.to_vec())
+            .send(Bytes::copy_from_slice(buf))
             .await
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::BrokenPipe, e))
     }
@@ -114,15 +115,16 @@ impl SenderWriter {
 mod tests {
     use super::NoTtyEvent;
     use crate::event::{read, Event, KeyCode, KeyModifiers};
+    use bytes::Bytes;
 
     #[tokio::test]
     async fn read_parses_byte_fed_through_input_channel() {
         // Input channel: host -> crossterm parser.
-        let (input_tx, input_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let (input_tx, input_rx) = tokio::sync::mpsc::channel::<Bytes>(8);
         let (pty, _query_rx) = NoTtyEvent::new(input_rx);
 
         // Feed a plain 'a' keystroke.
-        input_tx.send(b"a".to_vec()).await.unwrap();
+        input_tx.send(Bytes::from_static(b"a")).await.unwrap();
 
         let event = read(&pty).await.unwrap();
         assert_eq!(event, Event::Key(KeyCode::Char('a').into()));

--- a/src/event/internal_no_tty.rs
+++ b/src/event/internal_no_tty.rs
@@ -1,25 +1,30 @@
 use super::internal::InternalEvent;
 use crate::event::source::no_tty::NoTtyInternalEventSource;
-use crate::event::source::EventSource;
-use crate::event::{filter::Filter, read::InternalEventReader, timeout::PollTimeout};
+use crate::event::{filter::Filter, read::InternalEventReader};
 use crate::terminal::WindowSize;
-use crossbeam_channel::{bounded, Receiver, Sender};
 use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+use tokio::sync::Mutex as AsyncMutex;
 
 #[derive(Clone)]
 pub struct NoTtyEvent {
     pub(crate) send: Sender<Vec<u8>>,
     pub window_size: Arc<Mutex<WindowSize>>,
-    inner: Arc<Mutex<InternalEventReader>>,
+    inner: Arc<AsyncMutex<InternalEventReader>>,
 }
 
 impl NoTtyEvent {
+    /// Creates a new no-tty event handle.
+    ///
+    /// `recv` is the channel that carries raw input bytes (e.g. from an SSH client) into
+    /// crossterm's parser. The returned [`Receiver`] carries crossterm's outgoing query
+    /// escape sequences (cursor position, keyboard enhancement) back to the host.
     pub fn new(recv: Receiver<Vec<u8>>) -> (Self, Receiver<Vec<u8>>) {
-        let (s, r) = bounded(0);
+        let (s, r) = channel(16);
         let source = NoTtyInternalEventSource::new(recv);
-        let source = source.ok().map(|x| Box::new(x) as Box<dyn EventSource>);
+        let source = source.ok().map(Box::new);
         let event = InternalEventReader::default().with_source(source);
 
         (
@@ -31,48 +36,63 @@ impl NoTtyEvent {
                     width: 0,
                     height: 0,
                 })),
-                inner: Arc::new(Mutex::new(event)),
+                inner: Arc::new(AsyncMutex::new(event)),
             },
             r,
         )
     }
+
     /// Polls to check if there are any `InternalEvent`s that can be read within the given duration.
-    pub(crate) fn poll<F>(&self, timeout: Option<Duration>, filter: &F) -> std::io::Result<bool>
+    pub(crate) async fn poll<F>(
+        &self,
+        timeout: Option<Duration>,
+        filter: &F,
+    ) -> std::io::Result<bool>
     where
         F: Filter,
     {
-        let (mut reader, timeout) = if let Some(timeout) = timeout {
-            let poll_timeout = PollTimeout::new(Some(timeout));
-            if let Some(reader) = self.inner.try_lock_for(timeout) {
-                (reader, poll_timeout.leftover())
-            } else {
-                return Ok(false);
+        match timeout {
+            // Bound the whole operation (lock acquisition + read) by the timeout. If it
+            // elapses we report "no event", matching the old try_lock_for behavior.
+            Some(timeout) => {
+                match tokio::time::timeout(timeout, async {
+                    let mut reader = self.inner.lock().await;
+                    reader.poll_async(Some(timeout), filter).await
+                })
+                .await
+                {
+                    Ok(res) => res,
+                    Err(_elapsed) => Ok(false),
+                }
             }
-        } else {
-            (self.inner.lock(), None)
-        };
-        reader.poll(timeout, filter)
+            None => {
+                let mut reader = self.inner.lock().await;
+                reader.poll_async(None, filter).await
+            }
+        }
     }
 
     /// Reads a single `InternalEvent`.
-    pub(crate) fn read<F>(&self, filter: &F) -> std::io::Result<InternalEvent>
+    pub(crate) async fn read<F>(&self, filter: &F) -> std::io::Result<InternalEvent>
     where
         F: Filter,
     {
-        let mut reader = self.inner.lock();
-        reader.read(filter)
+        let mut reader = self.inner.lock().await;
+        reader.read_async(filter).await
     }
 
     /// Reads a single `InternalEvent`. Non-blocking.
-    pub(crate) fn try_read<F>(&self, filter: &F) -> Option<InternalEvent>
+    pub(crate) async fn try_read<F>(&self, filter: &F) -> Option<InternalEvent>
     where
         F: Filter,
     {
-        let mut reader = self.inner.lock();
+        let mut reader = self.inner.lock().await;
         reader.try_read(filter)
     }
 }
 
+/// An async writer over an mpsc channel, used to forward crossterm command output
+/// (ANSI escape sequences) to the host that owns the receiving end.
 #[derive(Clone)]
 pub struct SenderWriter(tokio::sync::mpsc::Sender<Vec<u8>>);
 
@@ -80,18 +100,12 @@ impl SenderWriter {
     pub fn new(sender: tokio::sync::mpsc::Sender<Vec<u8>>) -> Self {
         Self(sender)
     }
-}
 
-impl std::io::Write for SenderWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+    /// Sends the given bytes over the channel, awaiting capacity.
+    pub async fn write_all(&self, buf: &[u8]) -> std::io::Result<()> {
         self.0
-            .blocking_send(buf.to_vec())
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        // mpsc is unbuffered; nothing to flush
-        Ok(())
+            .send(buf.to_vec())
+            .await
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::BrokenPipe, e))
     }
 }

--- a/src/event/read.rs
+++ b/src/event/read.rs
@@ -9,14 +9,19 @@ use crate::event::source::windows::WindowsEventSource;
 #[cfg(feature = "event-stream")]
 #[cfg(not(feature = "no-tty"))]
 use crate::event::sys::Waker;
-use crate::event::{
-    filter::Filter, internal::InternalEvent, source::EventSource, timeout::PollTimeout,
-};
+use crate::event::{filter::Filter, internal::InternalEvent, timeout::PollTimeout};
+#[cfg(not(feature = "no-tty"))]
+use crate::event::source::EventSource;
+#[cfg(feature = "no-tty")]
+use crate::event::source::no_tty::NoTtyInternalEventSource;
 
 /// Can be used to read `InternalEvent`s.
 pub(crate) struct InternalEventReader {
     events: VecDeque<InternalEvent>,
+    #[cfg(not(feature = "no-tty"))]
     source: Option<Box<dyn EventSource>>,
+    #[cfg(feature = "no-tty")]
+    source: Option<Box<NoTtyInternalEventSource>>,
     skipped_events: Vec<InternalEvent>,
 }
 
@@ -51,6 +56,7 @@ impl InternalEventReader {
         self.source.as_ref().expect("reader source not set").waker()
     }
 
+    #[cfg(not(feature = "no-tty"))]
     pub(crate) fn poll<F>(&mut self, timeout: Option<Duration>, filter: &F) -> io::Result<bool>
     where
         F: Filter,
@@ -110,6 +116,7 @@ impl InternalEventReader {
     ///
     /// Internally, we use `try_read`, which buffers the events that do not fulfill the filter
     /// conditions to prevent stalling the thread in an infinite loop.
+    #[cfg(not(feature = "no-tty"))]
     pub(crate) fn read<F>(&mut self, filter: &F) -> io::Result<InternalEvent>
     where
         F: Filter,
@@ -121,6 +128,79 @@ impl InternalEventReader {
             }
 
             let _ = self.poll(None, filter)?;
+        }
+    }
+
+    #[cfg(feature = "no-tty")]
+    pub(crate) async fn poll_async<F>(
+        &mut self,
+        timeout: Option<Duration>,
+        filter: &F,
+    ) -> io::Result<bool>
+    where
+        F: Filter,
+    {
+        for event in &self.events {
+            if filter.eval(event) {
+                return Ok(true);
+            }
+        }
+
+        let event_source = match self.source.as_mut() {
+            Some(source) => source,
+            None => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "Failed to initialize input reader",
+                ))
+            }
+        };
+
+        let poll_timeout = PollTimeout::new(timeout);
+
+        loop {
+            let maybe_event = match event_source.try_read(poll_timeout.leftover()).await {
+                Ok(None) => None,
+                Ok(Some(event)) => {
+                    if filter.eval(&event) {
+                        Some(event)
+                    } else {
+                        self.skipped_events.push(event);
+                        None
+                    }
+                }
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::Interrupted {
+                        return Ok(false);
+                    }
+                    return Err(e);
+                }
+            };
+
+            if poll_timeout.elapsed() || maybe_event.is_some() {
+                self.events.extend(self.skipped_events.drain(..));
+
+                if let Some(event) = maybe_event {
+                    self.events.push_front(event);
+                    return Ok(true);
+                }
+
+                return Ok(false);
+            }
+        }
+    }
+
+    #[cfg(feature = "no-tty")]
+    pub(crate) async fn read_async<F>(&mut self, filter: &F) -> io::Result<InternalEvent>
+    where
+        F: Filter,
+    {
+        loop {
+            if let Some(event) = self.try_read(filter) {
+                return Ok(event);
+            }
+
+            let _ = self.poll_async(None, filter).await?;
         }
     }
 
@@ -156,13 +236,14 @@ impl InternalEventReader {
 
     #[cfg(unix)]
     #[cfg(feature = "no-tty")]
-    pub(crate) fn with_source(mut self, source: Option<Box<dyn EventSource>>) -> Self {
+    pub(crate) fn with_source(mut self, source: Option<Box<NoTtyInternalEventSource>>) -> Self {
         self.source = source;
         self
     }
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no-tty"))]
 mod tests {
     use std::io;
     use std::{collections::VecDeque, time::Duration};

--- a/src/event/read.rs
+++ b/src/event/read.rs
@@ -1,19 +1,19 @@
 use std::{collections::vec_deque::VecDeque, io, time::Duration};
 
+#[cfg(feature = "no-tty")]
+use crate::event::source::no_tty::NoTtyInternalEventSource;
 #[cfg(unix)]
 #[cfg(not(feature = "no-tty"))]
 use crate::event::source::unix::UnixInternalEventSource;
 #[cfg(windows)]
 #[cfg(not(feature = "no-tty"))]
 use crate::event::source::windows::WindowsEventSource;
+#[cfg(not(feature = "no-tty"))]
+use crate::event::source::EventSource;
 #[cfg(feature = "event-stream")]
 #[cfg(not(feature = "no-tty"))]
 use crate::event::sys::Waker;
 use crate::event::{filter::Filter, internal::InternalEvent, timeout::PollTimeout};
-#[cfg(not(feature = "no-tty"))]
-use crate::event::source::EventSource;
-#[cfg(feature = "no-tty")]
-use crate::event::source::no_tty::NoTtyInternalEventSource;
 
 /// Can be used to read `InternalEvent`s.
 pub(crate) struct InternalEventReader {

--- a/src/event/source.rs
+++ b/src/event/source.rs
@@ -2,11 +2,17 @@ use std::{io, time::Duration};
 
 use super::internal::InternalEvent;
 #[cfg(feature = "event-stream")]
+#[cfg(not(feature = "no-tty"))]
 use super::sys::Waker;
 
 #[cfg(unix)]
+#[cfg(feature = "no-tty")]
+pub(crate) mod no_tty;
+#[cfg(unix)]
+#[cfg(not(feature = "no-tty"))]
 pub(crate) mod unix;
 #[cfg(windows)]
+#[cfg(not(feature = "no-tty"))]
 pub(crate) mod windows;
 
 /// An interface for trying to read an `InternalEvent` within an optional `Duration`.
@@ -23,5 +29,6 @@ pub(crate) trait EventSource: Sync + Send {
 
     /// Returns a `Waker` allowing to wake/force the `try_read` method to return `Ok(None)`.
     #[cfg(feature = "event-stream")]
+    #[cfg(not(feature = "no-tty"))]
     fn waker(&self) -> Waker;
 }

--- a/src/event/source.rs
+++ b/src/event/source.rs
@@ -1,5 +1,7 @@
+#[cfg(not(feature = "no-tty"))]
 use std::{io, time::Duration};
 
+#[cfg(not(feature = "no-tty"))]
 use super::internal::InternalEvent;
 #[cfg(feature = "event-stream")]
 #[cfg(not(feature = "no-tty"))]
@@ -16,6 +18,7 @@ pub(crate) mod unix;
 pub(crate) mod windows;
 
 /// An interface for trying to read an `InternalEvent` within an optional `Duration`.
+#[cfg(not(feature = "no-tty"))]
 pub(crate) trait EventSource: Sync + Send {
     /// Tries to read an `InternalEvent` within the given duration.
     ///
@@ -29,6 +32,5 @@ pub(crate) trait EventSource: Sync + Send {
 
     /// Returns a `Waker` allowing to wake/force the `try_read` method to return `Ok(None)`.
     #[cfg(feature = "event-stream")]
-    #[cfg(not(feature = "no-tty"))]
     fn waker(&self) -> Waker;
 }

--- a/src/event/source/no_tty.rs
+++ b/src/event/source/no_tty.rs
@@ -1,0 +1,128 @@
+use std::{collections::VecDeque, io, time::Duration};
+
+use crossbeam_channel::{Receiver, RecvTimeoutError};
+
+use crate::event::{
+    internal::InternalEvent, source::EventSource, sys::unix::parse::parse_event,
+    timeout::PollTimeout,
+};
+
+pub struct NoTtyInternalEventSource {
+    parser: Parser,
+    recv: Receiver<Vec<u8>>,
+}
+
+impl NoTtyInternalEventSource {
+    pub fn new(recv: Receiver<Vec<u8>>) -> io::Result<Self> {
+        Ok(NoTtyInternalEventSource {
+            parser: Parser::default(),
+            recv,
+        })
+    }
+}
+
+impl EventSource for NoTtyInternalEventSource {
+    fn try_read(&mut self, timeout: Option<Duration>) -> io::Result<Option<InternalEvent>> {
+        if let Some(event) = self.parser.next() {
+            return Ok(Some(event));
+        }
+
+        let timeout = PollTimeout::new(timeout);
+
+        loop {
+            let t = timeout
+                .leftover()
+                .unwrap_or(std::time::Duration::from_secs(u64::MAX));
+            let data = match self.recv.recv_timeout(t) {
+                Ok(d) => d,
+                Err(RecvTimeoutError::Timeout) => return Ok(None),
+                // NOTE: fake io error
+                Err(e) => return Err(io::Error::new(io::ErrorKind::Other, e)),
+            };
+
+            if data.is_empty() {
+                return Ok(None);
+            }
+            self.parser.advance(&data, false);
+
+            if let Some(event) = self.parser.next() {
+                return Ok(Some(event));
+            }
+
+            // Processing above can take some time, check if timeout expired
+            if timeout.elapsed() {
+                return Ok(None);
+            }
+        }
+    }
+}
+
+//
+// Following `Parser` structure exists for two reasons:
+//
+//  * mimic anes Parser interface
+//  * move the advancing, parsing, ... stuff out of the `try_read` method
+//
+#[derive(Debug)]
+struct Parser {
+    buffer: Vec<u8>,
+    internal_events: VecDeque<InternalEvent>,
+}
+
+impl Default for Parser {
+    fn default() -> Self {
+        Parser {
+            // This buffer is used for -> 1 <- ANSI escape sequence. Are we
+            // aware of any ANSI escape sequence that is bigger? Can we make
+            // it smaller?
+            //
+            // Probably not worth spending more time on this as "there's a plan"
+            // to use the anes crate parser.
+            buffer: Vec::with_capacity(256),
+            // TTY_BUFFER_SIZE is 1_024 bytes. How many ANSI escape sequences can
+            // fit? What is an average sequence length? Let's guess here
+            // and say that the average ANSI escape sequence length is 8 bytes. Thus
+            // the buffer size should be 1024/8=128 to avoid additional allocations
+            // when processing large amounts of data.
+            //
+            // There's no need to make it bigger, because when you look at the `try_read`
+            // method implementation, all events are consumed before the next TTY_BUFFER
+            // is processed -> events pushed.
+            internal_events: VecDeque::with_capacity(128),
+        }
+    }
+}
+
+impl Parser {
+    fn advance(&mut self, buffer: &[u8], more: bool) {
+        for (idx, byte) in buffer.iter().enumerate() {
+            let more = idx + 1 < buffer.len() || more;
+
+            self.buffer.push(*byte);
+
+            match parse_event(&self.buffer, more) {
+                Ok(Some(ie)) => {
+                    self.internal_events.push_back(ie);
+                    self.buffer.clear();
+                }
+                Ok(None) => {
+                    // Event can't be parsed, because we don't have enough bytes for
+                    // the current sequence. Keep the buffer and process next bytes.
+                }
+                Err(_) => {
+                    // Event can't be parsed (not enough parameters, parameter is not a number, ...).
+                    // Clear the buffer and continue with another sequence.
+                    self.buffer.clear();
+                }
+            }
+        }
+    }
+}
+
+impl Iterator for Parser {
+    type Item = InternalEvent;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.internal_events.pop_front()
+    }
+}

--- a/src/event/source/no_tty.rs
+++ b/src/event/source/no_tty.rs
@@ -1,10 +1,9 @@
 use std::{collections::VecDeque, io, time::Duration};
 
-use crossbeam_channel::{Receiver, RecvTimeoutError};
+use tokio::sync::mpsc::Receiver;
 
 use crate::event::{
-    internal::InternalEvent, source::EventSource, sys::unix::parse::parse_event,
-    timeout::PollTimeout,
+    internal::InternalEvent, sys::unix::parse::parse_event, timeout::PollTimeout,
 };
 
 pub struct NoTtyInternalEventSource {
@@ -19,10 +18,16 @@ impl NoTtyInternalEventSource {
             recv,
         })
     }
-}
 
-impl EventSource for NoTtyInternalEventSource {
-    fn try_read(&mut self, timeout: Option<Duration>) -> io::Result<Option<InternalEvent>> {
+    /// Tries to read an `InternalEvent` within the given duration.
+    ///
+    /// Returns `Ok(None)` if the timeout expires before an event is available, and an
+    /// error with kind [`io::ErrorKind::BrokenPipe`] if the input channel's sender has
+    /// been dropped.
+    pub(crate) async fn try_read(
+        &mut self,
+        timeout: Option<Duration>,
+    ) -> io::Result<Option<InternalEvent>> {
         if let Some(event) = self.parser.next() {
             return Ok(Some(event));
         }
@@ -33,11 +38,17 @@ impl EventSource for NoTtyInternalEventSource {
             let t = timeout
                 .leftover()
                 .unwrap_or(std::time::Duration::from_secs(u64::MAX));
-            let data = match self.recv.recv_timeout(t) {
-                Ok(d) => d,
-                Err(RecvTimeoutError::Timeout) => return Ok(None),
-                // NOTE: fake io error
-                Err(e) => return Err(io::Error::new(io::ErrorKind::Other, e)),
+            let data = match tokio::time::timeout(t, self.recv.recv()).await {
+                Ok(Some(d)) => d,
+                // Sender dropped: signal a broken pipe so callers can bail out.
+                Ok(None) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        "no-tty input channel disconnected",
+                    ))
+                }
+                // Timed out waiting for data.
+                Err(_elapsed) => return Ok(None),
             };
 
             if data.is_empty() {

--- a/src/event/source/no_tty.rs
+++ b/src/event/source/no_tty.rs
@@ -2,9 +2,7 @@ use std::{collections::VecDeque, io, time::Duration};
 
 use tokio::sync::mpsc::Receiver;
 
-use crate::event::{
-    internal::InternalEvent, sys::unix::parse::parse_event, timeout::PollTimeout,
-};
+use crate::event::{internal::InternalEvent, sys::unix::parse::parse_event, timeout::PollTimeout};
 
 pub struct NoTtyInternalEventSource {
     parser: Parser,

--- a/src/event/source/no_tty.rs
+++ b/src/event/source/no_tty.rs
@@ -1,16 +1,17 @@
 use std::{collections::VecDeque, io, time::Duration};
 
+use bytes::Bytes;
 use tokio::sync::mpsc::Receiver;
 
 use crate::event::{internal::InternalEvent, sys::unix::parse::parse_event, timeout::PollTimeout};
 
 pub struct NoTtyInternalEventSource {
     parser: Parser,
-    recv: Receiver<Vec<u8>>,
+    recv: Receiver<Bytes>,
 }
 
 impl NoTtyInternalEventSource {
-    pub fn new(recv: Receiver<Vec<u8>>) -> io::Result<Self> {
+    pub fn new(recv: Receiver<Bytes>) -> io::Result<Self> {
         Ok(NoTtyInternalEventSource {
             parser: Parser::default(),
             recv,

--- a/src/event/sys.rs
+++ b/src/event/sys.rs
@@ -1,9 +1,12 @@
 #[cfg(all(unix, feature = "event-stream"))]
+#[cfg(not(feature = "no-tty"))]
 pub(crate) use unix::waker::Waker;
 #[cfg(all(windows, feature = "event-stream"))]
+#[cfg(not(feature = "no-tty"))]
 pub(crate) use windows::waker::Waker;
 
 #[cfg(unix)]
 pub(crate) mod unix;
 #[cfg(windows)]
+#[cfg(not(feature = "no-tty"))]
 pub(crate) mod windows;

--- a/src/event/sys/unix.rs
+++ b/src/event/sys/unix.rs
@@ -1,4 +1,5 @@
 #[cfg(feature = "event-stream")]
+#[cfg(not(feature = "no-tty"))]
 pub(crate) mod waker;
 
 #[cfg(feature = "events")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,10 +255,12 @@ pub mod tty;
 pub mod clipboard;
 
 #[cfg(windows)]
+#[cfg(not(feature = "no-tty"))]
 /// A module that exposes one function to check if the current terminal supports ANSI sequences.
 pub mod ansi_support;
 mod command;
 pub(crate) mod macros;
 
 #[cfg(all(windows, not(feature = "windows")))]
+#[cfg(not(feature = "no-tty"))]
 compile_error!("Compiling on Windows with \"windows\" feature disabled. Feature \"windows\" should only be disabled when project will never be compiled on Windows.");

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -178,6 +178,7 @@ mod tests {
     }
 
     #[cfg(not(windows))]
+    #[cfg(not(feature = "no-tty"))]
     mod unix {
         use std::fmt;
 
@@ -242,6 +243,7 @@ mod tests {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     mod windows {
         use std::fmt;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -126,6 +126,52 @@ macro_rules! execute {
     }}
 }
 
+/// Queues one or more command(s) onto an async [`SenderWriter`](crate::event::SenderWriter).
+///
+/// Unlike the synchronous [`queue!`], the channel-backed writer has no separate flush
+/// step: the serialized commands are sent as soon as the returned future is awaited.
+///
+/// Returns a future resolving to `std::io::Result<()>`.
+#[cfg(feature = "no-tty")]
+#[macro_export]
+macro_rules! async_queue {
+    ($writer:expr $(, $command:expr)* $(,)?) => {{
+        async {
+            let mut __buf = ::std::string::String::new();
+            let mut __ok = true;
+            $(
+                if __ok
+                    && $crate::Command::write_ansi(&$command, &mut __buf).is_err()
+                {
+                    __ok = false;
+                }
+            )*
+            if __ok {
+                $crate::event::SenderWriter::write_all($writer, __buf.as_bytes()).await
+            } else {
+                ::std::result::Result::Err(::std::io::Error::new(
+                    ::std::io::ErrorKind::Other,
+                    "failed to write ANSI command",
+                ))
+            }
+        }
+    }};
+}
+
+/// Executes one or more command(s) on an async [`SenderWriter`](crate::event::SenderWriter).
+///
+/// For the channel-backed writer this is identical to [`async_queue!`]: awaiting the
+/// returned future sends the serialized commands immediately.
+///
+/// Returns a future resolving to `std::io::Result<()>`.
+#[cfg(feature = "no-tty")]
+#[macro_export]
+macro_rules! async_execute {
+    ($writer:expr $(, $command:expr)* $(,)?) => {{
+        $crate::async_queue!($writer $(, $command)*)
+    }};
+}
+
 #[doc(hidden)]
 #[macro_export]
 macro_rules! impl_display {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -150,7 +150,7 @@ macro_rules! async_queue {
                 $crate::event::SenderWriter::write_all($writer, __buf.as_bytes()).await
             } else {
                 ::std::result::Result::Err(::std::io::Error::new(
-                    ::std::io::ErrorKind::Other,
+                    ::std::io::ErrorKind::InvalidData,
                     "failed to write ANSI command",
                 ))
             }

--- a/src/style.rs
+++ b/src/style.rs
@@ -162,6 +162,7 @@ pub fn style<D: Display>(val: D) -> StyledContent<D> {
 /// This does not always provide a good result.
 pub fn available_color_count() -> u16 {
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     {
         // Check if we're running in a pseudo TTY, which supports true color.
         // Fall back to env vars otherwise for other terminals on Windows.
@@ -211,6 +212,7 @@ impl Command for SetForegroundColor {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         sys::windows::set_foreground_color(self.0)
     }
@@ -235,6 +237,7 @@ impl Command for SetBackgroundColor {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         sys::windows::set_background_color(self.0)
     }
@@ -259,6 +262,7 @@ impl Command for SetUnderlineColor {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         Err(std::io::Error::new(
             std::io::ErrorKind::Other,
@@ -314,6 +318,7 @@ impl Command for SetColors {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         if let Some(color) = self.0.foreground {
             sys::windows::set_foreground_color(color)?;
@@ -341,6 +346,7 @@ impl Command for SetAttribute {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         // attributes are not supported by WinAPI.
         Ok(())
@@ -368,6 +374,7 @@ impl Command for SetAttributes {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         // attributes are not supported by WinAPI.
         Ok(())
@@ -401,11 +408,13 @@ impl Command for SetStyle {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         panic!("tried to execute SetStyle command using WinAPI, use ANSI instead");
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn is_ansi_code_supported(&self) -> bool {
         true
     }
@@ -468,6 +477,7 @@ impl<D: Display> Command for PrintStyledContent<D> {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         Ok(())
     }
@@ -487,6 +497,7 @@ impl Command for ResetColor {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         sys::windows::reset()
     }
@@ -504,11 +515,13 @@ impl<T: Display> Command for Print<T> {
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn execute_winapi(&self) -> std::io::Result<()> {
         panic!("tried to execute Print command using WinAPI, use ANSI instead");
     }
 
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn is_ansi_code_supported(&self) -> bool {
         true
     }
@@ -543,6 +556,7 @@ mod tests {
     macro_rules! skip_windows_ansi_supported {
         () => {
             #[cfg(windows)]
+            #[cfg(not(feature = "no-tty"))]
             {
                 if crate::ansi_support::supports_ansi() {
                     return;
@@ -553,6 +567,7 @@ mod tests {
 
     #[cfg_attr(windows, test)]
     #[cfg(windows)]
+    #[cfg(not(feature = "no-tty"))]
     fn windows_always_truecolor() {
         // This should always be true on supported Windows 10+,
         // but downlevel Windows clients and other terminals may fail `cargo test` otherwise.

--- a/src/style/sys.rs
+++ b/src/style/sys.rs
@@ -1,2 +1,3 @@
 #[cfg(windows)]
+#[cfg(not(feature = "no-tty"))]
 pub(crate) mod windows;

--- a/src/terminal/sys.rs
+++ b/src/terminal/sys.rs
@@ -2,26 +2,45 @@
 
 #[cfg(unix)]
 #[cfg(feature = "events")]
+#[cfg(not(feature = "no-tty"))]
 pub use self::unix::supports_keyboard_enhancement;
 #[cfg(unix)]
+#[cfg(not(feature = "no-tty"))]
 pub(crate) use self::unix::{
     disable_raw_mode, enable_raw_mode, is_raw_mode_enabled, size, window_size,
 };
-#[cfg(windows)]
+#[cfg(all(windows, not(feature = "no-tty")))]
 #[cfg(feature = "events")]
 pub use self::windows::supports_keyboard_enhancement;
-#[cfg(all(windows, test))]
+#[cfg(all(windows, test, not(feature = "no-tty")))]
 pub(crate) use self::windows::temp_screen_buffer;
-#[cfg(windows)]
+#[cfg(all(windows, not(feature = "no-tty")))]
 pub(crate) use self::windows::{
     clear, disable_raw_mode, enable_raw_mode, is_raw_mode_enabled, scroll_down, scroll_up,
     set_size, set_window_title, size, window_size,
 };
 
-#[cfg(windows)]
+#[cfg(all(windows, not(feature = "no-tty")))]
 mod windows;
 
 #[cfg(unix)]
+#[cfg(not(feature = "no-tty"))]
 pub mod file_descriptor;
 #[cfg(unix)]
+#[cfg(not(feature = "no-tty"))]
 mod unix;
+
+#[cfg(unix)]
+#[cfg(feature = "no-tty")]
+pub(crate) use self::no_tty::{
+    disable_raw_mode, enable_raw_mode, is_raw_mode_enabled, size, window_size,
+};
+
+#[cfg(unix)]
+#[cfg(feature = "no-tty")]
+mod no_tty;
+
+#[cfg(unix)]
+#[cfg(feature = "events")]
+#[cfg(feature = "no-tty")]
+pub use self::no_tty::supports_keyboard_enhancement;

--- a/src/terminal/sys/no_tty.rs
+++ b/src/terminal/sys/no_tty.rs
@@ -1,0 +1,129 @@
+//! Non-terminal related logic for terminal manipulation.
+
+use crate::event::internal_no_tty::NoTtyEvent;
+#[cfg(feature = "events")]
+use crate::event::KeyboardEnhancementFlags;
+use crate::terminal::WindowSize;
+use std::io;
+
+pub(crate) fn is_raw_mode_enabled() -> bool {
+    true
+}
+
+pub(crate) fn window_size(event: &NoTtyEvent) -> io::Result<WindowSize> {
+    let win = event.window_size.lock();
+    let size = WindowSize {
+        rows: win.rows,
+        columns: win.columns,
+        width: win.width,
+        height: win.height,
+    };
+    Ok(size)
+}
+
+#[allow(clippy::useless_conversion)]
+pub(crate) fn size(event: &NoTtyEvent) -> io::Result<(u16, u16)> {
+    match window_size(event) {
+        Ok(window_size) => Ok((window_size.columns, window_size.rows)),
+        Err(e) => Err(e),
+    }
+}
+
+pub(crate) fn enable_raw_mode() -> io::Result<()> {
+    Ok(())
+}
+
+/// Reset the raw mode.
+///
+/// More precisely, reset the whole termios mode to what it was before the first call
+/// to [enable_raw_mode]. If you don't mess with termios outside of crossterm, it's
+/// effectively disabling the raw mode and doing nothing else.
+pub(crate) fn disable_raw_mode() -> io::Result<()> {
+    Ok(())
+}
+
+/// Queries the terminal's support for progressive keyboard enhancement.
+///
+/// On unix systems, this function will block and possibly time out while
+/// [`crossterm::event::read`](crate::event::read) or [`crossterm::event::poll`](crate::event::poll) are being called.
+#[cfg(feature = "events")]
+pub fn supports_keyboard_enhancement(event: &NoTtyEvent) -> io::Result<bool> {
+    query_keyboard_enhancement_flags(event).map(|flags| flags.is_some())
+}
+
+/// Queries the terminal's currently active keyboard enhancement flags.
+///
+/// On unix systems, this function will block and possibly time out while
+/// [`crossterm::event::read`](crate::event::read) or [`crossterm::event::poll`](crate::event::poll) are being called.
+#[cfg(feature = "events")]
+pub fn query_keyboard_enhancement_flags(
+    event: &NoTtyEvent,
+) -> io::Result<Option<KeyboardEnhancementFlags>> {
+    if is_raw_mode_enabled() {
+        query_keyboard_enhancement_flags_raw(event)
+    } else {
+        query_keyboard_enhancement_flags_nonraw(event)
+    }
+}
+
+#[cfg(feature = "events")]
+fn query_keyboard_enhancement_flags_nonraw(
+    event: &NoTtyEvent,
+) -> io::Result<Option<KeyboardEnhancementFlags>> {
+    enable_raw_mode()?;
+    let flags = query_keyboard_enhancement_flags_raw(event);
+    disable_raw_mode()?;
+    flags
+}
+
+#[cfg(feature = "events")]
+fn query_keyboard_enhancement_flags_raw(
+    event: &NoTtyEvent,
+) -> io::Result<Option<KeyboardEnhancementFlags>> {
+    use crate::event::{
+        filter::{KeyboardEnhancementFlagsFilter, PrimaryDeviceAttributesFilter},
+        internal::InternalEvent,
+    };
+    use std::time::Duration;
+
+    // This is the recommended method for testing support for the keyboard enhancement protocol.
+    // We send a query for the flags supported by the terminal and then the primary device attributes
+    // query. If we receive the primary device attributes response but not the keyboard enhancement
+    // flags, none of the flags are supported.
+    //
+    // See <https://sw.kovidgoyal.net/kitty/keyboard-protocol/#detection-of-support-for-this-protocol>
+
+    // ESC [ ? u        Query progressive keyboard enhancement flags (kitty protocol).
+    // ESC [ c          Query primary device attributes.
+    const QUERY: &[u8] = b"\x1B[?u\x1B[c";
+
+    event
+        .send
+        .send_timeout(QUERY.into(), Duration::from_secs(1))
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+    loop {
+        match event.poll(
+            Some(Duration::from_millis(2000)),
+            &KeyboardEnhancementFlagsFilter,
+        ) {
+            Ok(true) => {
+                match event.read(&KeyboardEnhancementFlagsFilter) {
+                    Ok(InternalEvent::KeyboardEnhancementFlags(current_flags)) => {
+                        // Flush the PrimaryDeviceAttributes out of the event queue.
+                        event.read(&PrimaryDeviceAttributesFilter).ok();
+                        return Ok(Some(current_flags));
+                    }
+                    _ => return Ok(None),
+                }
+            }
+            Ok(false) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "The keyboard enhancement status could not be read within a normal duration",
+                ));
+            }
+            Err(_) => {}
+        }
+    }
+}

--- a/src/terminal/sys/no_tty.rs
+++ b/src/terminal/sys/no_tty.rs
@@ -103,7 +103,7 @@ async fn query_keyboard_enhancement_flags_raw(
 
     event
         .send
-        .send_timeout(QUERY.into(), Duration::from_secs(1))
+        .send_timeout(bytes::Bytes::from_static(QUERY), Duration::from_secs(1))
         .await
         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 

--- a/src/terminal/sys/no_tty.rs
+++ b/src/terminal/sys/no_tty.rs
@@ -44,8 +44,9 @@ pub(crate) fn disable_raw_mode() -> io::Result<()> {
 
 /// Queries the terminal's support for progressive keyboard enhancement.
 ///
-/// On unix systems, this function will block and possibly time out while
-/// [`crossterm::event::read`](crate::event::read) or [`crossterm::event::poll`](crate::event::poll) are being called.
+/// This sends a query out the event handle's query channel and awaits the response. It
+/// may time out while [`crossterm::event::read`](crate::event::read) or
+/// [`crossterm::event::poll`](crate::event::poll) are being awaited.
 #[cfg(feature = "events")]
 pub async fn supports_keyboard_enhancement(event: &NoTtyEvent) -> io::Result<bool> {
     query_keyboard_enhancement_flags(event)
@@ -55,8 +56,9 @@ pub async fn supports_keyboard_enhancement(event: &NoTtyEvent) -> io::Result<boo
 
 /// Queries the terminal's currently active keyboard enhancement flags.
 ///
-/// On unix systems, this function will block and possibly time out while
-/// [`crossterm::event::read`](crate::event::read) or [`crossterm::event::poll`](crate::event::poll) are being called.
+/// This sends a query out the event handle's query channel and awaits the response. It
+/// may time out while [`crossterm::event::read`](crate::event::read) or
+/// [`crossterm::event::poll`](crate::event::poll) are being awaited.
 #[cfg(feature = "events")]
 pub async fn query_keyboard_enhancement_flags(
     event: &NoTtyEvent,

--- a/src/terminal/sys/no_tty.rs
+++ b/src/terminal/sys/no_tty.rs
@@ -47,8 +47,10 @@ pub(crate) fn disable_raw_mode() -> io::Result<()> {
 /// On unix systems, this function will block and possibly time out while
 /// [`crossterm::event::read`](crate::event::read) or [`crossterm::event::poll`](crate::event::poll) are being called.
 #[cfg(feature = "events")]
-pub fn supports_keyboard_enhancement(event: &NoTtyEvent) -> io::Result<bool> {
-    query_keyboard_enhancement_flags(event).map(|flags| flags.is_some())
+pub async fn supports_keyboard_enhancement(event: &NoTtyEvent) -> io::Result<bool> {
+    query_keyboard_enhancement_flags(event)
+        .await
+        .map(|flags| flags.is_some())
 }
 
 /// Queries the terminal's currently active keyboard enhancement flags.
@@ -56,28 +58,28 @@ pub fn supports_keyboard_enhancement(event: &NoTtyEvent) -> io::Result<bool> {
 /// On unix systems, this function will block and possibly time out while
 /// [`crossterm::event::read`](crate::event::read) or [`crossterm::event::poll`](crate::event::poll) are being called.
 #[cfg(feature = "events")]
-pub fn query_keyboard_enhancement_flags(
+pub async fn query_keyboard_enhancement_flags(
     event: &NoTtyEvent,
 ) -> io::Result<Option<KeyboardEnhancementFlags>> {
     if is_raw_mode_enabled() {
-        query_keyboard_enhancement_flags_raw(event)
+        query_keyboard_enhancement_flags_raw(event).await
     } else {
-        query_keyboard_enhancement_flags_nonraw(event)
+        query_keyboard_enhancement_flags_nonraw(event).await
     }
 }
 
 #[cfg(feature = "events")]
-fn query_keyboard_enhancement_flags_nonraw(
+async fn query_keyboard_enhancement_flags_nonraw(
     event: &NoTtyEvent,
 ) -> io::Result<Option<KeyboardEnhancementFlags>> {
     enable_raw_mode()?;
-    let flags = query_keyboard_enhancement_flags_raw(event);
+    let flags = query_keyboard_enhancement_flags_raw(event).await;
     disable_raw_mode()?;
     flags
 }
 
 #[cfg(feature = "events")]
-fn query_keyboard_enhancement_flags_raw(
+async fn query_keyboard_enhancement_flags_raw(
     event: &NoTtyEvent,
 ) -> io::Result<Option<KeyboardEnhancementFlags>> {
     use crate::event::{
@@ -100,18 +102,22 @@ fn query_keyboard_enhancement_flags_raw(
     event
         .send
         .send_timeout(QUERY.into(), Duration::from_secs(1))
+        .await
         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
     loop {
-        match event.poll(
-            Some(Duration::from_millis(2000)),
-            &KeyboardEnhancementFlagsFilter,
-        ) {
+        match event
+            .poll(
+                Some(Duration::from_millis(2000)),
+                &KeyboardEnhancementFlagsFilter,
+            )
+            .await
+        {
             Ok(true) => {
-                match event.read(&KeyboardEnhancementFlagsFilter) {
+                match event.read(&KeyboardEnhancementFlagsFilter).await {
                     Ok(InternalEvent::KeyboardEnhancementFlags(current_flags)) => {
                         // Flush the PrimaryDeviceAttributes out of the event queue.
-                        event.read(&PrimaryDeviceAttributesFilter).ok();
+                        event.read(&PrimaryDeviceAttributesFilter).await.ok();
                         return Ok(Some(current_flags));
                     }
                     _ => return Ok(None),

--- a/src/terminal/sys/no_tty.rs
+++ b/src/terminal/sys/no_tty.rs
@@ -129,6 +129,10 @@ async fn query_keyboard_enhancement_flags_raw(
                     "The keyboard enhancement status could not be read within a normal duration",
                 ));
             }
+            // The input channel disconnected; propagate so the caller can stop.
+            Err(e) if e.kind() == io::ErrorKind::BrokenPipe => {
+                return Err(e);
+            }
             Err(_) => {}
         }
     }

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -3,12 +3,12 @@
 //! This module defines the IsTty trait and the is_tty method to
 //! return true if the item represents a terminal.
 
-#[cfg(unix)]
+#[cfg(all(unix, not(feature = "no-tty")))]
 use std::os::unix::io::AsRawFd;
-#[cfg(windows)]
+#[cfg(all(windows, not(feature = "no-tty")))]
 use std::os::windows::io::AsRawHandle;
 
-#[cfg(windows)]
+#[cfg(all(windows, not(feature = "no-tty")))]
 use winapi::um::consoleapi::GetConsoleMode;
 
 /// Adds the `is_tty` method to types that might represent a terminal
@@ -26,7 +26,7 @@ pub trait IsTty {
 
 /// On UNIX, the `isatty()` function returns true if a file
 /// descriptor is a terminal.
-#[cfg(all(unix, feature = "libc"))]
+#[cfg(all(unix, feature = "libc", not(feature = "no-tty")))]
 impl<S: AsRawFd> IsTty for S {
     fn is_tty(&self) -> bool {
         let fd = self.as_raw_fd();
@@ -34,7 +34,7 @@ impl<S: AsRawFd> IsTty for S {
     }
 }
 
-#[cfg(all(unix, not(feature = "libc")))]
+#[cfg(all(unix, not(feature = "libc"), not(feature = "no-tty")))]
 impl<S: AsRawFd> IsTty for S {
     fn is_tty(&self) -> bool {
         let fd = self.as_raw_fd();
@@ -44,7 +44,7 @@ impl<S: AsRawFd> IsTty for S {
 
 /// On windows, `GetConsoleMode` will return true if we are in a terminal.
 /// Otherwise false.
-#[cfg(windows)]
+#[cfg(all(windows, not(feature = "no-tty")))]
 impl<S: AsRawHandle> IsTty for S {
     fn is_tty(&self) -> bool {
         let mut mode = 0;


### PR DESCRIPTION
This PR adds an experimental `no-tty` Cargo feature that allows the crate to be used in some environments where spawning a new pseudo-terminal (PTY) per session is impossible—e.g. when using Tokio, which does not support `fork`.  
---

**Background & Motivation**  
- The russh ecosystem is async-only today.  
- Tokio’s runtime is **not** `fork`-safe, so we cannot allocate a new PTY for every incoming SSH session inside the async worker.  
- Without this feature, downstream users who only need *exec*/*subsystem* channels (and never interactive shells) are blocked from adopting the library.  

---

**Key Changes**  
- Added optional feature `no-tty` in `Cargo.toml`.  
- Gate all PTY allocation logic behind `#[cfg(not(feature = "no-tty"))]`.  
- Provide stub implementations that return `ChannelFailure` when a client requests a PTY while the feature is active.  
- Added `examples/ssh-service.rs` that starts a minimal async SSH server with `no-tty` enabled for quick testing.  

---

**Testing**  
1. Check out this branch  
2. `cargo run --example ssh-service --features no-tty`  
3. Connect with any SSH client:  
   ```bash
   ssh 127.0.0.1 -p 2222 -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no"
   ```
---