### PR TITLE
fix: make cursor `read_position_raw` skip older cursor pos events

### DIFF
--- a/src/cursor/sys/unix.rs
+++ b/src/cursor/sys/unix.rs
@@ -33,6 +33,9 @@ fn read_position() -> io::Result<(u16, u16)> {
 }
 
 fn read_position_raw() -> io::Result<(u16, u16)> {
+    // Discard any buffered cursor-position replies from earlier `ESC[6n` requests so the
+    // position returned below corresponds to the fresh request we are about to send.
+    // Poll with a zero timeout to drain only already-available events without blocking.
     while let Ok(true) = internal::poll(Some(Duration::ZERO), &CursorPositionFilter) {
         let _ = internal::read(&CursorPositionFilter);
     }


### PR DESCRIPTION
This PR is addressing issues https://github.com/nushell/nushell/issues/17179 and https://github.com/nushell/reedline/issues/860.

If cursor position was requested from the terminal by something other than crossterm itself (for example via `printf "\e[6n"` in nushell), then `cursor::position()` will be experiencing a permanent lag in cursor positions due to `read_position_raw` requesting a new pos, but consuming only an old event.

To fix this, I made `read_position_raw` discard all pending cursor pos events before requesting a new one.