### PR TITLE
fix: open /dev/tty in write mode to query keyboard enhancement flags

### DIFF
--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -230,10 +230,13 @@ fn query_keyboard_enhancement_flags_raw() -> io::Result<Option<KeyboardEnhanceme
     // ESC [ c          Query primary device attributes.
     const QUERY: &[u8] = b"\x1B[?u\x1B[c";
 
-    let result = File::open("/dev/tty").and_then(|mut file| {
-        file.write_all(QUERY)?;
-        file.flush()
-    });
+    let result = File::options()
+        .write(true)
+        .open("/dev/tty")
+        .and_then(|mut file| {
+            file.write_all(QUERY)?;
+            file.flush()
+        });
     if result.is_err() {
         let mut stdout = io::stdout();
         stdout.write_all(QUERY)?;


### PR DESCRIPTION
The keyboard enhancement flags query would always fail (and fall back to querying stdout) because `/dev/tty` was being opened as read-only.