### PR TITLE
fix: const fn for ContentStyle and StyledContent

### DIFF
--- a/src/style/content_style.rs
+++ b/src/style/content_style.rs
@@ -18,16 +18,21 @@ pub struct ContentStyle {
 }
 
 impl ContentStyle {
-    /// Creates a `StyledContent` by applying the style to the given `val`.
+    /// Creates a [`StyledContent`] by applying the style to the given `val`.
     #[inline]
-    pub fn apply<D: Display>(self, val: D) -> StyledContent<D> {
+    pub const fn apply<D: Display>(self, val: D) -> StyledContent<D> {
         StyledContent::new(self, val)
     }
 
-    /// Creates a new `ContentStyle`.
+    /// Creates a new [`ContentStyle`].
     #[inline]
-    pub fn new() -> ContentStyle {
-        ContentStyle::default()
+    pub const fn new() -> ContentStyle {
+        Self {
+            foreground_color: None,
+            background_color: None,
+            underline_color: None,
+            attributes: Attributes::none(),
+        }
     }
 }
 

--- a/src/style/styled_content.rs
+++ b/src/style/styled_content.rs
@@ -27,28 +27,28 @@ pub struct StyledContent<D: Display> {
 }
 
 impl<D: Display> StyledContent<D> {
-    /// Creates a new `StyledContent`.
+    /// Creates a new [`StyledContent`].
     #[inline]
-    pub fn new(style: ContentStyle, content: D) -> StyledContent<D> {
+    pub const fn new(style: ContentStyle, content: D) -> StyledContent<D> {
         StyledContent { style, content }
     }
 
     /// Returns the content.
     #[inline]
-    pub fn content(&self) -> &D {
+    pub const fn content(&self) -> &D {
         &self.content
     }
 
     /// Returns the style.
     #[inline]
-    pub fn style(&self) -> &ContentStyle {
+    pub const fn style(&self) -> &ContentStyle {
         &self.style
     }
 
     /// Returns a mutable reference to the style, so that it can be further
     /// manipulated
     #[inline]
-    pub fn style_mut(&mut self) -> &mut ContentStyle {
+    pub const fn style_mut(&mut self) -> &mut ContentStyle {
         &mut self.style
     }
 }


### PR DESCRIPTION
Closes https://github.com/crossterm-rs/crossterm/issues/760

feature(const_fn_trait_bound) is stabilised since rust 1.61