### PR TITLE
Better cursor position validation

### DIFF
--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -250,8 +250,10 @@ pub(crate) fn parse_csi_cursor_position(buffer: &[u8]) -> io::Result<Option<Inte
 
     let mut split = s.split(';');
 
-    let y = next_parsed::<u16>(&mut split)? - 1;
-    let x = next_parsed::<u16>(&mut split)? - 1;
+    let y = next_parsed::<u16>(&mut split)?
+        .checked_sub(1).ok_or_else(could_not_parse_event_error)?;
+    let x = next_parsed::<u16>(&mut split)?
+        .checked_sub(1).ok_or_else(could_not_parse_event_error)?;
 
     Ok(Some(InternalEvent::CursorPosition(x, y)))
 }
@@ -676,8 +678,10 @@ pub(crate) fn parse_csi_rxvt_mouse(buffer: &[u8]) -> io::Result<Option<InternalE
         .ok_or_else(could_not_parse_event_error)?;
     let (kind, modifiers) = parse_cb(cb)?;
 
-    let cx = next_parsed::<u16>(&mut split)? - 1;
-    let cy = next_parsed::<u16>(&mut split)? - 1;
+    let cx = next_parsed::<u16>(&mut split)?
+        .checked_sub(1).ok_or_else(could_not_parse_event_error)?;
+    let cy = next_parsed::<u16>(&mut split)?
+        .checked_sub(1).ok_or_else(could_not_parse_event_error)?;
 
     Ok(Some(InternalEvent::Event(Event::Mouse(MouseEvent {
         kind,
@@ -734,8 +738,10 @@ pub(crate) fn parse_csi_sgr_mouse(buffer: &[u8]) -> io::Result<Option<InternalEv
     // See http://www.xfree86.org/current/ctlseqs.html#Mouse%20Tracking
     // The upper left character position on the terminal is denoted as 1,1.
     // Subtract 1 to keep it synced with cursor
-    let cx = next_parsed::<u16>(&mut split)? - 1;
-    let cy = next_parsed::<u16>(&mut split)? - 1;
+    let cx = next_parsed::<u16>(&mut split)?
+        .checked_sub(1).ok_or_else(could_not_parse_event_error)?;
+    let cy = next_parsed::<u16>(&mut split)?
+        .checked_sub(1).ok_or_else(could_not_parse_event_error)?;
 
     // When button 3 in Cb is used to represent mouse release, you can't tell which button was
     // released. SGR mode solves this by having the sequence end with a lowercase m if it's a


### PR DESCRIPTION
I've just got this traceback:
```
3: crossterm::event::sys::unix::parse::parse_csi_cursor_position
          at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossterm-0.29.0/src/event/sys/unix/parse.rs:254:13
4: crossterm::event::sys::unix::parse::parse_csi
          at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossterm-0.29.0/src/event/sys/unix/parse.rs:204:40
5: crossterm::event::sys::unix::parse::parse_event
          at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossterm-0.29.0/src/event/sys/unix/parse.rs:76:29
6: crossterm::event::source::unix::mio::Parser::advance
          at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossterm-0.29.0/src/event/source/unix/mio.rs:204:19
7: <crossterm::event::source::unix::mio::UnixInternalEventSource as crossterm::event::source::EventSource>::try_read
          at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/crossterm-0.29.0/src/event/source/unix/mio.rs:99:53
```
The input is weird by itself. I should look to that too, but still is not a reason for panic.

Also fixed few other very similar places.