### PR TITLE
Added Cubic VM to 'used by' list

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ This can disable `mio` / `signal-hook` / `signal-hook-mio` dependencies.
 - [Ratatui](https://github.com/ratatui/ratatui)
 - [Rust-sloth](https://github.com/ecumene/rust-sloth)
 - [Rusty-rain](https://github.com/cowboy8625/rusty-rain)
+- [Cubic VM](https://github.com/cubic-vm/cubic)
 
 ## Contributing
   


### PR DESCRIPTION
Cubic VM is a lightweight command‑line manager for virtual machines written in Rust. It uses Crossterm for CLI‑related operations such as raw mode.