### PR TITLE
WIP: Color palette querying and change detection

### DIFF
--- a/src/colors.rs
+++ b/src/colors.rs
@@ -1,0 +1,87 @@
+//! # Colors
+//!
+//! The `colors` module provides functionality to query the terminal for colors
+//! and color-related capabilities.
+//!
+//! * [`query_terminal_colors`] — fetch the RGB values of foreground, background,
+//!   cursor, or palette colors.
+//! * [`query_color_scheme`] — detect whether the terminal is in light or dark mode.
+//!
+//! Color scheme *change* notifications are delivered as
+//! [`Event::ColorSchemeChanged`](crate::event::Event::ColorSchemeChanged) when
+//! [`EnableColorSchemeDetection`](crate::event::EnableColorSchemeDetection) is active.
+
+pub(crate) mod sys;
+
+pub use sys::{query_color_scheme, query_terminal_colors};
+
+/// Terminal color type, used in queries and responses.
+///
+/// `Palette(n)` uses OSC 4. The remaining variants use OSC 10..=19.
+#[derive(Debug, PartialOrd, PartialEq, Hash, Clone, Copy, Eq)]
+pub enum ColorType {
+    Palette(u8),
+    Foreground,
+    Background,
+    Cursor,
+    PointerForeground,
+    PointerBackground,
+    TektronixForeground,
+    TektronixBackground,
+    HighlightBackground,
+    TektronixCursor,
+    HighlightForeground,
+}
+
+impl ColorType {
+    /// Maps an OSC number (10..=19) to the corresponding `ColorType` variant.
+    pub(crate) fn from_osc_number(n: u8) -> Option<Self> {
+        match n {
+            10 => Some(Self::Foreground),
+            11 => Some(Self::Background),
+            12 => Some(Self::Cursor),
+            13 => Some(Self::PointerForeground),
+            14 => Some(Self::PointerBackground),
+            15 => Some(Self::TektronixForeground),
+            16 => Some(Self::TektronixBackground),
+            17 => Some(Self::HighlightBackground),
+            18 => Some(Self::TektronixCursor),
+            19 => Some(Self::HighlightForeground),
+            _ => None,
+        }
+    }
+
+    /// Returns the OSC number for this color type.
+    pub(crate) fn osc_number(&self) -> u8 {
+        match self {
+            Self::Palette(_) => 4,
+            Self::Foreground => 10,
+            Self::Background => 11,
+            Self::Cursor => 12,
+            Self::PointerForeground => 13,
+            Self::PointerBackground => 14,
+            Self::TektronixForeground => 15,
+            Self::TektronixBackground => 16,
+            Self::HighlightBackground => 17,
+            Self::TektronixCursor => 18,
+            Self::HighlightForeground => 19,
+        }
+    }
+}
+
+/// The terminal's color scheme preference (dark or light).
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, PartialOrd, Ord, PartialEq, Hash, Clone, Copy, Eq)]
+pub enum ColorScheme {
+    Dark,
+    Light,
+}
+
+/// A parsed color response from the terminal.
+#[derive(Debug, PartialOrd, PartialEq, Hash, Clone, Eq)]
+pub(crate) struct ColorEntry {
+    pub color_type: ColorType,
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}

--- a/src/colors/sys.rs
+++ b/src/colors/sys.rs
@@ -1,0 +1,11 @@
+//! This module provides platform related functions.
+
+#[cfg(unix)]
+pub use self::unix::{query_color_scheme, query_terminal_colors};
+#[cfg(windows)]
+pub use self::windows::{query_color_scheme, query_terminal_colors};
+
+#[cfg(unix)]
+pub(crate) mod unix;
+#[cfg(windows)]
+pub(crate) mod windows;

--- a/src/colors/sys/unix.rs
+++ b/src/colors/sys/unix.rs
@@ -1,0 +1,118 @@
+use std::{
+    io::{self, Write},
+    time::Duration,
+};
+
+use crate::colors::{ColorEntry, ColorScheme, ColorType};
+use crate::event::{
+    filter::{ColorQueryFilter, ColorSchemeFilter},
+    internal::{self, InternalEvent},
+    write_query,
+};
+
+/// Queries the terminal for the RGB values of the given color types.
+///
+/// Returns one `(u8, u8, u8)` per input element, in the same order.
+///
+/// This function must be called while raw mode is enabled.
+pub fn query_terminal_colors(colors: &[ColorType]) -> io::Result<Vec<(u8, u8, u8)>> {
+    // Drain stale responses.
+    while internal::poll(Some(Duration::ZERO), &ColorQueryFilter)? {
+        internal::read(&ColorQueryFilter)?;
+    }
+
+    let mut query: Vec<u8> = Vec::new();
+    for color in colors {
+        let n = color.osc_number();
+        match color {
+            ColorType::Palette(index) => {
+                write!(query, "\x1B]{n};{index};?\x1B\\")?;
+            }
+            _ => {
+                write!(query, "\x1B]{n};?\x1B\\")?;
+            }
+        }
+    }
+
+    // DA1 response arrives after all OSC replies.
+    query.extend_from_slice(b"\x1B[c");
+
+    write_query(&query)?;
+
+    let mut results: Vec<(u8, u8, u8)> = Vec::with_capacity(colors.len());
+    let timeout = Duration::from_secs(2);
+
+    loop {
+        if !internal::poll(Some(timeout), &ColorQueryFilter)? {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "The terminal colors could not be read within a normal duration",
+            ));
+        }
+        match internal::read(&ColorQueryFilter)? {
+            InternalEvent::PrimaryDeviceAttributes => {
+                if results.len() != colors.len() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        "The terminal did not respond with all requested colors",
+                    ));
+                }
+                return Ok(results);
+            }
+            InternalEvent::ColorResponse(ColorEntry {
+                color_type,
+                r,
+                g,
+                b,
+            }) => {
+                if colors.get(results.len()) != Some(&color_type) {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        "The terminal responded incorrectly",
+                    ));
+                }
+                results.push((r, g, b));
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Queries the terminal for the current color scheme (dark or light mode).
+///
+/// This function must be called while raw mode is enabled.
+pub fn query_color_scheme() -> io::Result<ColorScheme> {
+    // Drain stale responses.
+    while internal::poll(Some(Duration::ZERO), &ColorSchemeFilter)? {
+        internal::read(&ColorSchemeFilter)?;
+    }
+
+    // DA1 response arrives after the scheme reply.
+    write_query(b"\x1B[?996n\x1B[c")?;
+
+    let timeout = Duration::from_secs(2);
+    let mut scheme: Option<ColorScheme> = None;
+
+    loop {
+        if !internal::poll(Some(timeout), &ColorSchemeFilter)? {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "The terminal color scheme could not be read within a normal duration",
+            ));
+        }
+        match internal::read(&ColorSchemeFilter)? {
+            InternalEvent::PrimaryDeviceAttributes => {
+                return scheme.ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::Other,
+                        "The terminal did not respond with a color scheme",
+                    )
+                });
+            }
+            InternalEvent::ColorSchemeResponse(s) => {
+                scheme = Some(s);
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/colors/sys/windows.rs
+++ b/src/colors/sys/windows.rs
@@ -1,0 +1,23 @@
+use std::io;
+
+use crate::colors::{ColorScheme, ColorType};
+
+/// Queries the terminal for the RGB values of the given color types.
+///
+/// Not supported on Windows; always returns an [`io::ErrorKind::Unsupported`] error.
+pub fn query_terminal_colors(_colors: &[ColorType]) -> io::Result<Vec<(u8, u8, u8)>> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "Querying terminal colors is not implemented for the Windows API.",
+    ))
+}
+
+/// Queries the terminal for the current color scheme (dark or light mode).
+///
+/// Not supported on Windows; always returns an [`io::ErrorKind::Unsupported`] error.
+pub fn query_color_scheme() -> io::Result<ColorScheme> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "Querying the color scheme is not implemented for the Windows API.",
+    ))
+}

--- a/src/cursor/sys/unix.rs
+++ b/src/cursor/sys/unix.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{self, Error, ErrorKind, Write},
+    io::{self, Error, ErrorKind},
     time::Duration,
 };
 
@@ -40,10 +40,8 @@ fn read_position_raw() -> io::Result<(u16, u16)> {
         let _ = internal::read(&CursorPositionFilter);
     }
 
-    // Use `ESC [ 6 n` to and retrieve the cursor position.
-    let mut stdout = io::stdout();
-    stdout.write_all(b"\x1B[6n")?;
-    stdout.flush()?;
+    // Use `ESC [ 6 n` to retrieve the cursor position.
+    crate::event::write_query(b"\x1B[6n")?;
 
     loop {
         match internal::poll(Some(Duration::from_millis(2000)), &CursorPositionFilter) {

--- a/src/event.rs
+++ b/src/event.rs
@@ -54,6 +54,7 @@
 //!             #[cfg(feature = "bracketed-paste")]
 //!             Event::Paste(data) => println!("{:?}", data),
 //!             Event::Resize(width, height) => println!("New size {}x{}", width, height),
+//!             Event::ColorSchemeChanged(scheme) => println!("{:?}", scheme),
 //!         }
 //!     }
 //!     execute!(
@@ -100,6 +101,7 @@
 //!                 #[cfg(feature = "bracketed-paste")]
 //!                 Event::Paste(data) => println!("Pasted {:?}", data),
 //!                 Event::Resize(width, height) => println!("New size {}x{}", width, height),
+//!                 Event::ColorSchemeChanged(scheme) => println!("{:?}", scheme),
 //!             }
 //!         } else {
 //!             // Timeout expired and no `Event` is available
@@ -132,12 +134,21 @@ use derive_more::derive::IsVariant;
 #[cfg(feature = "event-stream")]
 pub use stream::EventStream;
 
+pub use internal::{ColorScheme, ColorType};
+
 use crate::{
     csi,
     event::{filter::EventFilter, internal::InternalEvent},
     Command,
 };
+#[cfg(unix)]
+use crate::event::{
+    filter::{ColorQueryFilter, ColorSchemeFilter},
+    internal::ColorEntry,
+};
 use std::fmt::{self, Display};
+#[cfg(unix)]
+use std::io::Write;
 use std::time::Duration;
 
 use bitflags::bitflags;
@@ -231,6 +242,8 @@ pub fn read() -> std::io::Result<Event> {
     match internal::read(&EventFilter)? {
         InternalEvent::Event(event) => Ok(event),
         #[cfg(unix)]
+        InternalEvent::ColorSchemeResponse(scheme) => Ok(Event::ColorSchemeChanged(scheme)),
+        #[cfg(unix)]
         _ => unreachable!(),
     }
 }
@@ -259,6 +272,10 @@ pub fn read() -> std::io::Result<Event> {
 pub fn try_read() -> Option<Event> {
     match internal::try_read(&EventFilter) {
         Some(InternalEvent::Event(event)) => Some(event),
+        #[cfg(unix)]
+        Some(InternalEvent::ColorSchemeResponse(scheme)) => {
+            Some(Event::ColorSchemeChanged(scheme))
+        }
         None => None,
         #[cfg(unix)]
         _ => unreachable!(),
@@ -276,6 +293,117 @@ pub(crate) fn write_query(bytes: &[u8]) -> std::io::Result<()> {
     out.write_all(bytes)?;
     out.flush()?;
     Ok(())
+}
+
+/// Queries the terminal for the RGB values of the given color types.
+///
+/// Returns one `(u8, u8, u8)` per input element, in the same order.
+///
+/// This function must be called while raw mode is enabled.
+#[cfg(unix)]
+pub fn query_terminal_colors(
+    colors: &[ColorType],
+) -> std::io::Result<Vec<(u8, u8, u8)>> {
+    // Drain stale responses.
+    while internal::poll(Some(std::time::Duration::ZERO), &ColorQueryFilter)? {
+        internal::read(&ColorQueryFilter)?;
+    }
+
+    let mut query: Vec<u8> = Vec::new();
+    for color in colors {
+        let n = color.osc_number();
+        match color {
+            ColorType::Palette(index) => {
+                write!(query, "\x1B]{n};{index};?\x1B\\")?;
+            }
+            _ => {
+                write!(query, "\x1B]{n};?\x1B\\")?;
+            }
+        }
+    }
+
+    // DA1 response arrives after all OSC replies.
+    query.extend_from_slice(b"\x1B[c");
+
+    write_query(&query)?;
+
+    let mut results: Vec<(u8, u8, u8)> = Vec::with_capacity(colors.len());
+    let timeout = std::time::Duration::from_secs(2);
+
+    loop {
+        if !internal::poll(Some(timeout), &ColorQueryFilter)? {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "The terminal colors could not be read within a normal duration",
+            ));
+        }
+        match internal::read(&ColorQueryFilter)? {
+            InternalEvent::PrimaryDeviceAttributes => {
+                if results.len() != colors.len() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        "The terminal did not respond with all requested colors",
+                    ));
+                }
+                return Ok(results);
+            }
+            InternalEvent::ColorResponse(ColorEntry {
+                color_type,
+                r,
+                g,
+                b,
+            }) => {
+                if colors.get(results.len()) != Some(&color_type) {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        "The terminal responded incorrectly",
+                    ));
+                }
+                results.push((r, g, b));
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Queries the terminal for the current color scheme (dark or light mode).
+///
+/// This function must be called while raw mode is enabled.
+#[cfg(unix)]
+pub fn query_color_scheme() -> std::io::Result<ColorScheme> {
+    // Drain stale responses.
+    while internal::poll(Some(std::time::Duration::ZERO), &ColorSchemeFilter)? {
+        internal::read(&ColorSchemeFilter)?;
+    }
+
+    // DA1 response arrives after the scheme reply.
+    write_query(b"\x1B[?996n\x1B[c")?;
+
+    let timeout = std::time::Duration::from_secs(2);
+    let mut scheme: Option<ColorScheme> = None;
+
+    loop {
+        if !internal::poll(Some(timeout), &ColorSchemeFilter)? {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "The terminal color scheme could not be read within a normal duration",
+            ));
+        }
+        match internal::read(&ColorSchemeFilter)? {
+            InternalEvent::PrimaryDeviceAttributes => {
+                return scheme.ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        "The terminal did not respond with a color scheme",
+                    )
+                });
+            }
+            InternalEvent::ColorSchemeResponse(s) => {
+                scheme = Some(s);
+            }
+            _ => {}
+        }
+    }
 }
 
 bitflags! {
@@ -403,6 +531,38 @@ impl Command for DisableFocusChange {
     #[cfg(windows)]
     fn execute_winapi(&self) -> std::io::Result<()> {
         // Focus events can't be disabled on Windows
+        Ok(())
+    }
+}
+
+/// A command that enables color scheme change detection.
+///
+/// It should be paired with [`DisableColorSchemeDetection`] at the end of execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EnableColorSchemeDetection;
+
+impl Command for EnableColorSchemeDetection {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        f.write_str(csi!("?2031h"))
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// A command that disables color scheme change detection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DisableColorSchemeDetection;
+
+impl Command for DisableColorSchemeDetection {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        f.write_str(csi!("?2031l"))
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> std::io::Result<()> {
         Ok(())
     }
 }
@@ -560,6 +720,9 @@ pub enum Event {
     /// A resize event with new dimensions after resize (columns, rows).
     /// **Note** that resize events can occur in batches.
     Resize(u16, u16),
+    /// The terminal's color scheme changed. Only emitted if [`EnableColorSchemeDetection`]
+    /// has been enabled.
+    ColorSchemeChanged(ColorScheme),
 }
 
 impl Event {

--- a/src/event.rs
+++ b/src/event.rs
@@ -134,21 +134,13 @@ use derive_more::derive::IsVariant;
 #[cfg(feature = "event-stream")]
 pub use stream::EventStream;
 
-pub use internal::{ColorScheme, ColorType};
-
 use crate::{
+    colors::ColorScheme,
     csi,
     event::{filter::EventFilter, internal::InternalEvent},
     Command,
 };
-#[cfg(unix)]
-use crate::event::{
-    filter::{ColorQueryFilter, ColorSchemeFilter},
-    internal::ColorEntry,
-};
 use std::fmt::{self, Display};
-#[cfg(unix)]
-use std::io::Write;
 use std::time::Duration;
 
 use bitflags::bitflags;
@@ -293,117 +285,6 @@ pub(crate) fn write_query(bytes: &[u8]) -> std::io::Result<()> {
     out.write_all(bytes)?;
     out.flush()?;
     Ok(())
-}
-
-/// Queries the terminal for the RGB values of the given color types.
-///
-/// Returns one `(u8, u8, u8)` per input element, in the same order.
-///
-/// This function must be called while raw mode is enabled.
-#[cfg(unix)]
-pub fn query_terminal_colors(
-    colors: &[ColorType],
-) -> std::io::Result<Vec<(u8, u8, u8)>> {
-    // Drain stale responses.
-    while internal::poll(Some(std::time::Duration::ZERO), &ColorQueryFilter)? {
-        internal::read(&ColorQueryFilter)?;
-    }
-
-    let mut query: Vec<u8> = Vec::new();
-    for color in colors {
-        let n = color.osc_number();
-        match color {
-            ColorType::Palette(index) => {
-                write!(query, "\x1B]{n};{index};?\x1B\\")?;
-            }
-            _ => {
-                write!(query, "\x1B]{n};?\x1B\\")?;
-            }
-        }
-    }
-
-    // DA1 response arrives after all OSC replies.
-    query.extend_from_slice(b"\x1B[c");
-
-    write_query(&query)?;
-
-    let mut results: Vec<(u8, u8, u8)> = Vec::with_capacity(colors.len());
-    let timeout = std::time::Duration::from_secs(2);
-
-    loop {
-        if !internal::poll(Some(timeout), &ColorQueryFilter)? {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "The terminal colors could not be read within a normal duration",
-            ));
-        }
-        match internal::read(&ColorQueryFilter)? {
-            InternalEvent::PrimaryDeviceAttributes => {
-                if results.len() != colors.len() {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "The terminal did not respond with all requested colors",
-                    ));
-                }
-                return Ok(results);
-            }
-            InternalEvent::ColorResponse(ColorEntry {
-                color_type,
-                r,
-                g,
-                b,
-            }) => {
-                if colors.get(results.len()) != Some(&color_type) {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "The terminal responded incorrectly",
-                    ));
-                }
-                results.push((r, g, b));
-            }
-            _ => {}
-        }
-    }
-}
-
-/// Queries the terminal for the current color scheme (dark or light mode).
-///
-/// This function must be called while raw mode is enabled.
-#[cfg(unix)]
-pub fn query_color_scheme() -> std::io::Result<ColorScheme> {
-    // Drain stale responses.
-    while internal::poll(Some(std::time::Duration::ZERO), &ColorSchemeFilter)? {
-        internal::read(&ColorSchemeFilter)?;
-    }
-
-    // DA1 response arrives after the scheme reply.
-    write_query(b"\x1B[?996n\x1B[c")?;
-
-    let timeout = std::time::Duration::from_secs(2);
-    let mut scheme: Option<ColorScheme> = None;
-
-    loop {
-        if !internal::poll(Some(timeout), &ColorSchemeFilter)? {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "The terminal color scheme could not be read within a normal duration",
-            ));
-        }
-        match internal::read(&ColorSchemeFilter)? {
-            InternalEvent::PrimaryDeviceAttributes => {
-                return scheme.ok_or_else(|| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "The terminal did not respond with a color scheme",
-                    )
-                });
-            }
-            InternalEvent::ColorSchemeResponse(s) => {
-                scheme = Some(s);
-            }
-            _ => {}
-        }
-    }
 }
 
 bitflags! {

--- a/src/event.rs
+++ b/src/event.rs
@@ -265,6 +265,19 @@ pub fn try_read() -> Option<Event> {
     }
 }
 
+/// Writes a terminal query. Avoids writing to stdout when `use-dev-tty` is enabled since it may be piped.
+#[cfg(unix)]
+pub(crate) fn write_query(bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    #[cfg(feature = "use-dev-tty")]
+    let mut out = std::fs::OpenOptions::new().write(true).open("/dev/tty")?;
+    #[cfg(not(feature = "use-dev-tty"))]
+    let mut out = std::io::stdout();
+    out.write_all(bytes)?;
+    out.flush()?;
+    Ok(())
+}
+
 bitflags! {
     /// Represents special flags that tell compatible terminals to add extra information to keyboard events.
     ///

--- a/src/event/filter.rs
+++ b/src/event/filter.rs
@@ -46,13 +46,46 @@ impl Filter for PrimaryDeviceAttributesFilter {
     }
 }
 
+#[cfg(unix)]
+#[derive(Debug, Clone)]
+pub(crate) struct ColorQueryFilter;
+
+#[cfg(unix)]
+impl Filter for ColorQueryFilter {
+    fn eval(&self, event: &InternalEvent) -> bool {
+        // PrimaryDeviceAttributes signals all OSC replies are done.
+        matches!(
+            *event,
+            InternalEvent::ColorResponse(_) | InternalEvent::PrimaryDeviceAttributes
+        )
+    }
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone)]
+pub(crate) struct ColorSchemeFilter;
+
+#[cfg(unix)]
+impl Filter for ColorSchemeFilter {
+    fn eval(&self, event: &InternalEvent) -> bool {
+        // PrimaryDeviceAttributes signals the scheme reply is done.
+        matches!(
+            *event,
+            InternalEvent::ColorSchemeResponse(_) | InternalEvent::PrimaryDeviceAttributes
+        )
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct EventFilter;
 
 impl Filter for EventFilter {
     #[cfg(unix)]
     fn eval(&self, event: &InternalEvent) -> bool {
-        matches!(*event, InternalEvent::Event(_))
+        matches!(
+            *event,
+            InternalEvent::Event(_) | InternalEvent::ColorSchemeResponse(_)
+        )
     }
 
     #[cfg(windows)]

--- a/src/event/internal.rs
+++ b/src/event/internal.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
 
 #[cfg(unix)]
+use crate::colors::{ColorEntry, ColorScheme};
+#[cfg(unix)]
 use crate::event::KeyboardEnhancementFlags;
 use crate::event::{filter::Filter, read::InternalEventReader, timeout::PollTimeout, Event};
 
@@ -59,77 +61,6 @@ where
 {
     let mut reader = lock_event_reader();
     reader.try_read(filter)
-}
-
-/// Terminal color type, used in queries and responses.
-///
-/// `Palette(n)` uses OSC 4. The remaining variants use OSC 10..=19.
-#[derive(Debug, PartialOrd, PartialEq, Hash, Clone, Copy, Eq)]
-pub enum ColorType {
-    Palette(u8),
-    Foreground,
-    Background,
-    Cursor,
-    PointerForeground,
-    PointerBackground,
-    TektronixForeground,
-    TektronixBackground,
-    HighlightBackground,
-    TektronixCursor,
-    HighlightForeground,
-}
-
-impl ColorType {
-    /// Maps an OSC number (10..=19) to the corresponding `ColorType` variant.
-    pub(crate) fn from_osc_number(n: u8) -> Option<Self> {
-        match n {
-            10 => Some(Self::Foreground),
-            11 => Some(Self::Background),
-            12 => Some(Self::Cursor),
-            13 => Some(Self::PointerForeground),
-            14 => Some(Self::PointerBackground),
-            15 => Some(Self::TektronixForeground),
-            16 => Some(Self::TektronixBackground),
-            17 => Some(Self::HighlightBackground),
-            18 => Some(Self::TektronixCursor),
-            19 => Some(Self::HighlightForeground),
-            _ => None,
-        }
-    }
-
-    /// Returns the OSC number for this color type.
-    pub(crate) fn osc_number(&self) -> u8 {
-        match self {
-            Self::Palette(_) => 4,
-            Self::Foreground => 10,
-            Self::Background => 11,
-            Self::Cursor => 12,
-            Self::PointerForeground => 13,
-            Self::PointerBackground => 14,
-            Self::TektronixForeground => 15,
-            Self::TektronixBackground => 16,
-            Self::HighlightBackground => 17,
-            Self::TektronixCursor => 18,
-            Self::HighlightForeground => 19,
-        }
-    }
-}
-
-/// The terminal's color scheme preference (dark or light).
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, PartialOrd, Ord, PartialEq, Hash, Clone, Copy, Eq)]
-pub enum ColorScheme {
-    Dark,
-    Light,
-}
-
-/// A parsed color response from the terminal.
-#[derive(Debug, PartialOrd, PartialEq, Hash, Clone, Eq)]
-pub(crate) struct ColorEntry {
-    pub color_type: ColorType,
-    pub r: u8,
-    pub g: u8,
-    pub b: u8,
 }
 
 /// An internal event.

--- a/src/event/internal.rs
+++ b/src/event/internal.rs
@@ -61,6 +61,77 @@ where
     reader.try_read(filter)
 }
 
+/// Terminal color type, used in queries and responses.
+///
+/// `Palette(n)` uses OSC 4. The remaining variants use OSC 10..=19.
+#[derive(Debug, PartialOrd, PartialEq, Hash, Clone, Copy, Eq)]
+pub enum ColorType {
+    Palette(u8),
+    Foreground,
+    Background,
+    Cursor,
+    PointerForeground,
+    PointerBackground,
+    TektronixForeground,
+    TektronixBackground,
+    HighlightBackground,
+    TektronixCursor,
+    HighlightForeground,
+}
+
+impl ColorType {
+    /// Maps an OSC number (10..=19) to the corresponding `ColorType` variant.
+    pub(crate) fn from_osc_number(n: u8) -> Option<Self> {
+        match n {
+            10 => Some(Self::Foreground),
+            11 => Some(Self::Background),
+            12 => Some(Self::Cursor),
+            13 => Some(Self::PointerForeground),
+            14 => Some(Self::PointerBackground),
+            15 => Some(Self::TektronixForeground),
+            16 => Some(Self::TektronixBackground),
+            17 => Some(Self::HighlightBackground),
+            18 => Some(Self::TektronixCursor),
+            19 => Some(Self::HighlightForeground),
+            _ => None,
+        }
+    }
+
+    /// Returns the OSC number for this color type.
+    pub(crate) fn osc_number(&self) -> u8 {
+        match self {
+            Self::Palette(_) => 4,
+            Self::Foreground => 10,
+            Self::Background => 11,
+            Self::Cursor => 12,
+            Self::PointerForeground => 13,
+            Self::PointerBackground => 14,
+            Self::TektronixForeground => 15,
+            Self::TektronixBackground => 16,
+            Self::HighlightBackground => 17,
+            Self::TektronixCursor => 18,
+            Self::HighlightForeground => 19,
+        }
+    }
+}
+
+/// The terminal's color scheme preference (dark or light).
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, PartialOrd, Ord, PartialEq, Hash, Clone, Copy, Eq)]
+pub enum ColorScheme {
+    Dark,
+    Light,
+}
+
+/// A parsed color response from the terminal.
+#[derive(Debug, PartialOrd, PartialEq, Hash, Clone, Eq)]
+pub(crate) struct ColorEntry {
+    pub color_type: ColorType,
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
 /// An internal event.
 ///
 /// Encapsulates publicly available `Event` with additional internal
@@ -78,4 +149,10 @@ pub(crate) enum InternalEvent {
     /// Attributes and architectural class of the terminal.
     #[cfg(unix)]
     PrimaryDeviceAttributes,
+    /// A terminal color response (OSC 4 or OSC 10..=19).
+    #[cfg(unix)]
+    ColorResponse(ColorEntry),
+    /// A color scheme response (CSI ? 997 ; 1/2 n).
+    #[cfg(unix)]
+    ColorSchemeResponse(ColorScheme),
 }

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -1,11 +1,11 @@
 use std::io;
 
+use crate::colors::{ColorEntry, ColorScheme, ColorType};
+use crate::event::internal::InternalEvent;
 use crate::event::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, KeyboardEnhancementFlags,
     MediaKeyCode, ModifierKeyCode, MouseButton, MouseEvent, MouseEventKind,
 };
-
-use crate::event::internal::{ColorEntry, ColorScheme, ColorType, InternalEvent};
 
 // Event parsing
 //

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -5,7 +5,7 @@ use crate::event::{
     MediaKeyCode, ModifierKeyCode, MouseButton, MouseEvent, MouseEventKind,
 };
 
-use crate::event::internal::InternalEvent;
+use crate::event::internal::{ColorEntry, ColorScheme, ColorType, InternalEvent};
 
 // Event parsing
 //
@@ -74,6 +74,7 @@ pub(crate) fn parse_event(
                         }
                     }
                     b'[' => parse_csi(buffer),
+                    b']' => parse_osc(buffer),
                     b'\x1B' => Ok(Some(InternalEvent::Event(Event::Key(KeyCode::Esc.into())))),
                     _ => parse_event(&buffer[1..], input_available).map(|event_option| {
                         event_option.map(|event| {
@@ -180,6 +181,7 @@ pub(crate) fn parse_csi(buffer: &[u8]) -> io::Result<Option<InternalEvent>> {
         b'?' => match buffer[buffer.len() - 1] {
             b'u' => return parse_csi_keyboard_enhancement_flags(buffer),
             b'c' => return parse_csi_primary_device_attributes(buffer),
+            b'n' => return parse_csi_color_scheme_response(buffer),
             _ => None,
         },
         b'0'..=b'9' => {
@@ -298,6 +300,32 @@ fn parse_csi_primary_device_attributes(buffer: &[u8]) -> io::Result<Option<Inter
     // See <https://vt100.net/docs/vt510-rm/DA1.html>
 
     Ok(Some(InternalEvent::PrimaryDeviceAttributes))
+}
+
+fn parse_csi_color_scheme_response(buffer: &[u8]) -> io::Result<Option<InternalEvent>> {
+    // CSI ? 997 ; 1 n  (dark)
+    // CSI ? 997 ; 2 n  (light)
+    assert!(buffer.starts_with(b"\x1B[?"));
+    assert!(buffer.ends_with(b"n"));
+
+    let s = std::str::from_utf8(&buffer[3..buffer.len() - 1])
+        .map_err(|_| could_not_parse_event_error())?;
+
+    let mut split = s.split(';');
+
+    let code = next_parsed::<u16>(&mut split)?;
+    if code != 997 {
+        return Err(could_not_parse_event_error());
+    }
+
+    let mode = next_parsed::<u8>(&mut split)?;
+    let scheme = match mode {
+        1 => ColorScheme::Dark,
+        2 => ColorScheme::Light,
+        _ => return Err(could_not_parse_event_error()),
+    };
+
+    Ok(Some(InternalEvent::ColorSchemeResponse(scheme)))
 }
 
 fn parse_modifiers(mask: u8) -> KeyModifiers {
@@ -858,6 +886,84 @@ pub(crate) fn parse_utf8_char(buffer: &[u8]) -> io::Result<Option<char>> {
                 Err(could_not_parse_event_error())
             }
         }
+    }
+}
+
+fn find_osc_terminator(buffer: &[u8]) -> Option<usize> {
+    let mut i = 2; // skip ESC ]
+    while i < buffer.len() {
+        if buffer[i] == b'\x07' {
+            return Some(i + 1);
+        }
+        if buffer[i] == b'\x1B' && i + 1 < buffer.len() && buffer[i + 1] == b'\\' {
+            return Some(i + 2);
+        }
+        i += 1;
+    }
+    None
+}
+
+fn parse_color_channel(s: &str) -> Option<u8> {
+    // Terminals respond with 2-digit ("ff") or 4-digit ("ffff") hex.
+    let val = u16::from_str_radix(s, 16).ok()?;
+    Some(if s.len() <= 2 { val as u8 } else { (val >> 8) as u8 })
+}
+
+fn parse_rgb_spec(s: &str) -> Option<(u8, u8, u8)> {
+    let s = s.strip_prefix("rgb:")?;
+    let mut parts = s.split('/');
+    let r = parse_color_channel(parts.next()?)?;
+    let g = parse_color_channel(parts.next()?)?;
+    let b = parse_color_channel(parts.next()?)?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((r, g, b))
+}
+
+fn parse_osc(buffer: &[u8]) -> io::Result<Option<InternalEvent>> {
+    let end = match find_osc_terminator(buffer) {
+        Some(end) => end,
+        None => return Ok(None),
+    };
+
+    let terminator_len = if buffer[end - 1] == b'\\' { 2 } else { 1 };
+    let payload = std::str::from_utf8(&buffer[2..end - terminator_len])
+        .map_err(|_| could_not_parse_event_error())?;
+
+    let (osc_num_str, rest) = payload
+        .split_once(';')
+        .ok_or_else(could_not_parse_event_error)?;
+    let osc_num: u8 = osc_num_str
+        .parse()
+        .map_err(|_| could_not_parse_event_error())?;
+
+    if osc_num == 4 {
+        // OSC 4;{index};rgb:...
+        let (index_str, rgb_str) = rest
+            .split_once(';')
+            .ok_or_else(could_not_parse_event_error)?;
+        let index: u8 = index_str
+            .parse()
+            .map_err(|_| could_not_parse_event_error())?;
+        let (r, g, b) = parse_rgb_spec(rgb_str).ok_or_else(could_not_parse_event_error)?;
+        Ok(Some(InternalEvent::ColorResponse(ColorEntry {
+            color_type: ColorType::Palette(index),
+            r,
+            g,
+            b,
+        })))
+    } else if let Some(color_type) = ColorType::from_osc_number(osc_num) {
+        // OSC 10..=19;rgb:...
+        let (r, g, b) = parse_rgb_spec(rest).ok_or_else(could_not_parse_event_error)?;
+        Ok(Some(InternalEvent::ColorResponse(ColorEntry {
+            color_type,
+            r,
+            g,
+            b,
+        })))
+    } else {
+        Err(could_not_parse_event_error())
     }
 }
 
@@ -1502,5 +1608,54 @@ mod tests {
                 KeyEventKind::Release,
             )))),
         );
+    }
+
+    #[test]
+    fn test_parse_osc_color_response() {
+        // OSC 4 palette, BEL terminator, 4-digit hex.
+        assert_eq!(
+            parse_event(b"\x1B]4;1;rgb:ffff/0000/0000\x07", false).unwrap(),
+            Some(InternalEvent::ColorResponse(ColorEntry {
+                color_type: ColorType::Palette(1),
+                r: 0xff,
+                g: 0x00,
+                b: 0x00,
+            })),
+        );
+        // OSC 11 dynamic, ST terminator, 2-digit hex.
+        assert_eq!(
+            parse_event(b"\x1B]11;rgb:ab/cd/ef\x1B\\", false).unwrap(),
+            Some(InternalEvent::ColorResponse(ColorEntry {
+                color_type: ColorType::Background,
+                r: 0xab,
+                g: 0xcd,
+                b: 0xef,
+            })),
+        );
+    }
+
+    #[test]
+    fn test_parse_osc_color_errors() {
+        // No terminator yet, caller should keep buffering.
+        assert_eq!(parse_event(b"\x1B]10;rgb:ffff/ffff", false).unwrap(), None);
+        // Malformed rgb spec.
+        assert!(parse_event(b"\x1B]10;notacolor\x07", false).is_err());
+        // OSC 52 (clipboard) is not a color response we handle.
+        assert!(parse_event(b"\x1B]52;c;foo\x07", false).is_err());
+    }
+
+    #[test]
+    fn test_parse_csi_color_scheme_response() {
+        assert_eq!(
+            parse_event(b"\x1B[?997;1n", false).unwrap(),
+            Some(InternalEvent::ColorSchemeResponse(ColorScheme::Dark)),
+        );
+        assert_eq!(
+            parse_event(b"\x1B[?997;2n", false).unwrap(),
+            Some(InternalEvent::ColorSchemeResponse(ColorScheme::Light)),
+        );
+        // Invalid mode and wrong code.
+        assert!(parse_event(b"\x1B[?997;3n", false).is_err());
+        assert!(parse_event(b"\x1B[?998;1n", false).is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,6 +239,9 @@
 
 pub use crate::command::{Command, ExecutableCommand, QueueableCommand, SynchronizedUpdate};
 
+/// A module to query and work with terminal colors.
+#[cfg(feature = "events")]
+pub mod colors;
 /// A module to work with the terminal cursor
 pub mod cursor;
 /// A module to read events.


### PR DESCRIPTION
This PR introduces:
- querying terminal colors
- querying dark/light colorscheme
- colorscheme change notifications

`query_terminal_colors` takes a `ColorType` slice and returns RGB values by
using OSC 4 and 10–19. `query_color_scheme` uses `CSI ? 996 n` to ask whether
the terminal is in dark or light mode. `EnableColorSchemeDetection` and
`DisableColorSchemeDetection` toggle `CSI ? 2031 h/l`, and scheme changes come
through as `Event::ColorSchemeChanged`.

Both query functions put a trailing DA1 onto the request and read replies
until DA1 comes back. This matters more here than it would for
`cursor::position` because OSC color queries aren't as widely supported, so on
terminals that ignore them we'd otherwise wait the full 2000ms timeout.

Errors return `io::ErrorKind::Other` the same as `cursor::position`. Eventually
this could split into `TimedOut` and `Unsupported` (no DA1 vs DA1 with no
reply), but that applies equally to the cursor query, so I left them
consistent.

Manually tested on Kitty, Ghostty, and macOS Terminal.

https://contour-terminal.org/vt-extensions/color-palette-update-notifications/#example-source-code
https://ghostty.org/docs/vt/osc/4
https://ghostty.org/docs/vt/osc/1x
