### PR TITLE
fix tty poll fail for zero timeout

### DIFF
--- a/src/event/source/unix/tty.rs
+++ b/src/event/source/unix/tty.rs
@@ -123,11 +123,11 @@ impl EventSource for UnixInternalEventSource {
             make_pollfd(&self.wake_pipe.receiver),
         ];
 
+        // check if there are buffered events from the last read
+        if let Some(event) = self.parser.next() {
+            return Ok(Some(event));
+        }
         while timeout.leftover().map_or(true, |t| !t.is_zero()) {
-            // check if there are buffered events from the last read
-            if let Some(event) = self.parser.next() {
-                return Ok(Some(event));
-            }
             match poll(&mut fds, timeout.leftover()) {
                 Err(filedescriptor::Error::Poll(e)) | Err(filedescriptor::Error::Io(e)) => {
                     match e.kind() {


### PR DESCRIPTION
A zero timeout never enters the loop. We must check for buffered events beforehand as mio.rs does already.