### PR TITLE
fix(event): drain tty fd to EAGAIN before returning from try_read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Fixed 🐛
+
+- Drain tty fd to `WouldBlock` so large pastes don't stall under edge-triggered epoll (#1057)
+
 # Version 0.29
 
 ## Added ⭐

--- a/src/event/source/unix/mio.rs
+++ b/src/event/source/unix/mio.rs
@@ -93,6 +93,9 @@ impl EventSource for UnixInternalEventSource {
             for token in self.events.iter().map(|x| x.token()) {
                 match token {
                     TTY_TOKEN => {
+                        // mio uses edge-triggered epoll on Linux; drain to
+                        // WouldBlock before returning, or buffered bytes
+                        // stay unread until the next edge.
                         loop {
                             match self.tty_fd.read(&mut self.tty_buffer) {
                                 Ok(read_count) => {
@@ -101,6 +104,10 @@ impl EventSource for UnixInternalEventSource {
                                             &self.tty_buffer[..read_count],
                                             read_count == TTY_BUFFER_SIZE,
                                         );
+                                    }
+                                    if read_count < TTY_BUFFER_SIZE {
+                                        // Short read on a tty: nothing more buffered.
+                                        break;
                                     }
                                 }
                                 Err(e) => {
@@ -114,10 +121,10 @@ impl EventSource for UnixInternalEventSource {
                                     }
                                 }
                             };
+                        }
 
-                            if let Some(event) = self.parser.next() {
-                                return Ok(Some(event));
-                            }
+                        if let Some(event) = self.parser.next() {
+                            return Ok(Some(event));
                         }
                     }
                     SIGNAL_TOKEN => {


### PR DESCRIPTION
mio registers the tty fd with `Interest::READABLE`, which on Linux is `EPOLLIN | EPOLLET` (edge-triggered). The read loop returned as soon as the parser yielded its first event, leaving any remaining bytes in the kernel buffer. The edge has already been consumed, so `epoll_wait` won't re-fire until *new* data arrives.

Symptom: a large paste (e.g. tmux `paste-buffer`, no bracketed paste) stalls partway through and only resumes on the next keypress, which creates a new edge and drains the leftovers.

Fix: drain to `WouldBlock` — or a short read, which on a tty signals the same — before returning. Events queue in the parser; subsequent `try_read` calls drain them with no extra syscalls. The typical small-input fast path is unchanged: one short read, exit.

Repro inside tmux:

```
tmux load-buffer some-long-file.md
tmux paste-buffer -t <target-pane>
```

Tested on tmux 3.4, Linux 6.18. The `use-dev-tty` path uses level-triggered `poll()` and is unaffected.
