### PR TITLE
Bracketed paste limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Added ⭐
+
+- Configurable bracketed-paste limits via `set_bracketed_paste_limits` and `bracketed_paste_limits`. Paste accumulation can now be bounded by wall-clock duration and/or byte count; on overflow, the inflight buffer is discarded and a new `Event::PasteAborted` is emitted. Both bounds default to `None`, so existing behaviour is unchanged unless the caller opts in. Fixes terminal hangs when the closing `\x1B[201~` marker never arrives (e.g. tmux pane swaps).
+
 # Version 0.29
 
 ## Added ⭐

--- a/src/event.rs
+++ b/src/event.rs
@@ -53,6 +53,10 @@
 //!             Event::Mouse(event) => println!("{:?}", event),
 //!             #[cfg(feature = "bracketed-paste")]
 //!             Event::Paste(data) => println!("{:?}", data),
+//!             #[cfg(feature = "bracketed-paste")]
+//!             Event::PasteAborted { reason, buffered_bytes } => {
+//!                 println!("PasteAborted: {:?}, {} bytes lost", reason, buffered_bytes.len())
+//!             }
 //!             Event::Resize(width, height) => println!("New size {}x{}", width, height),
 //!         }
 //!     }
@@ -99,6 +103,10 @@
 //!                 Event::Mouse(event) => println!("{:?}", event),
 //!                 #[cfg(feature = "bracketed-paste")]
 //!                 Event::Paste(data) => println!("Pasted {:?}", data),
+//!                 #[cfg(feature = "bracketed-paste")]
+//!                 Event::PasteAborted { reason, buffered_bytes } => {
+//!                     println!("PasteAborted: {:?}, {} bytes lost", reason, buffered_bytes.len())
+//!                 }
 //!                 Event::Resize(width, height) => println!("New size {}x{}", width, height),
 //!             }
 //!         } else {
@@ -436,6 +444,99 @@ impl Command for DisableBracketedPaste {
     }
 }
 
+/// Limits applied to inflight bracketed pastes.
+///
+/// When bracketed paste mode is enabled, crossterm accumulates every byte received between
+/// the opening `ESC [ 200 ~` and closing `ESC [ 201 ~` markers into a single [`Event::Paste`].
+/// If the closing marker never arrives (e.g. the terminal lied about supporting
+/// bracketed paste, a tmux pane swap dropped it, etc.), the parser will buffer
+/// keystrokes indefinitely and the application will appear hung.
+///
+/// `BracketedPasteLimits` installs upper bounds on how long an unfinished paste may last
+/// and how many bytes it may accumulate. When either bound is exceeded, the inflight
+/// buffer is discarded and an [`Event::PasteAborted`] is emitted, allowing the
+/// application to recover and continue receiving normal input.
+///
+/// Both fields default to `None`, meaning no limits are imposed by default.
+/// Applications may configure global limits via [`set_bracketed_paste_limits`].
+///
+/// The limits are evaluated lazily when the next byte is processed, so a paste that
+/// stalls completely will only abort once additional input arrives.
+#[cfg(feature = "bracketed-paste")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BracketedPasteLimits {
+    /// Maximum wall-clock duration between the opening `ESC [ 200 ~` marker and the
+    /// closing `ESC [ 201 ~` marker. `None` disables the timeout.
+    pub max_duration: Option<Duration>,
+    /// Maximum number of bytes that may accumulate inside a single bracketed paste,
+    /// counting the `ESC [ 200 ~` prefix. `None` disables the limit.
+    pub max_bytes: Option<usize>,
+}
+
+/// Reason an inflight bracketed paste was aborted by crossterm.
+#[cfg(feature = "bracketed-paste")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum PasteAbortReason {
+    /// The paste exceeded [`BracketedPasteLimits::max_duration`].
+    Timeout,
+    /// The paste exceeded [`BracketedPasteLimits::max_bytes`].
+    SizeLimit,
+}
+
+#[cfg(feature = "bracketed-paste")]
+mod paste_limits {
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use super::BracketedPasteLimits;
+
+    /// Sentinel meaning "no limit configured".
+    const NO_DURATION: u64 = u64::MAX;
+    const NO_BYTES: usize = usize::MAX;
+
+    static MAX_DURATION_MILLIS: AtomicU64 = AtomicU64::new(NO_DURATION);
+    static MAX_BYTES: AtomicUsize = AtomicUsize::new(NO_BYTES);
+
+    pub(crate) fn store(limits: BracketedPasteLimits) {
+        let millis = limits
+            .max_duration
+            .and_then(|d| u64::try_from(d.as_millis()).ok())
+            .unwrap_or(NO_DURATION);
+        MAX_DURATION_MILLIS.store(millis, Ordering::Relaxed);
+        MAX_BYTES.store(limits.max_bytes.unwrap_or(NO_BYTES), Ordering::Relaxed);
+    }
+
+    pub(crate) fn load() -> BracketedPasteLimits {
+        let millis = MAX_DURATION_MILLIS.load(Ordering::Relaxed);
+        let bytes = MAX_BYTES.load(Ordering::Relaxed);
+        BracketedPasteLimits {
+            max_duration: (millis != NO_DURATION).then(|| Duration::from_millis(millis)),
+            max_bytes: (bytes != NO_BYTES).then_some(bytes),
+        }
+    }
+}
+
+/// Installs a set of [`BracketedPasteLimits`] used by the bracketed-paste parser.
+///
+/// These limits are global and apply to every [`read`], [`poll`], and [`EventStream`] caller.
+/// Calling this function replaces any previously installed limits.
+/// Pass `BracketedPasteLimits::default()` to clear all limits.
+///
+/// Limit checks run on the parser's input path and are essentially free when no
+/// paste is in progress, so the function is safe to call from any thread at any time.
+#[cfg(feature = "bracketed-paste")]
+pub fn set_bracketed_paste_limits(limits: BracketedPasteLimits) {
+    paste_limits::store(limits);
+}
+
+/// Returns the currently installed [`BracketedPasteLimits`].
+#[cfg(feature = "bracketed-paste")]
+pub fn bracketed_paste_limits() -> BracketedPasteLimits {
+    paste_limits::load()
+}
+
 /// A command that enables the [kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/), which adds extra information to keyboard events and removes ambiguity for modifier keys.
 ///
 /// It should be paired with [`PopKeyboardEnhancementFlags`] at the end of execution.
@@ -544,6 +645,23 @@ pub enum Event {
     /// enabled.
     #[cfg(feature = "bracketed-paste")]
     Paste(String),
+    /// A bracketed paste that was aborted before its closing marker arrived because the
+    /// configured [`BracketedPasteLimits`] were exceeded.
+    ///
+    /// Carries the reason for the abort along with the bytes that had been buffered for
+    /// the inflight paste, including the opening `ESC [ 200 ~` prefix.
+    ///
+    /// Only emitted if bracketed paste has been enabled and configured with limits via
+    /// [`set_bracketed_paste_limits`].
+    #[cfg(feature = "bracketed-paste")]
+    PasteAborted {
+        /// Why the paste was aborted.
+        reason: PasteAbortReason,
+        /// The bytes that had been buffered for the now-discarded inflight paste,
+        /// including the leading `ESC [ 200 ~` prefix. The application may inspect or
+        /// salvage them; crossterm itself will not.
+        buffered_bytes: Vec<u8>,
+    },
     /// A resize event with new dimensions after resize (columns, rows).
     /// **Note** that resize events can occur in batches.
     Resize(u16, u16),

--- a/src/event/source/unix.rs
+++ b/src/event/source/unix.rs
@@ -1,3 +1,5 @@
+pub(crate) mod parser;
+
 #[cfg(feature = "use-dev-tty")]
 pub(crate) mod tty;
 

--- a/src/event/source/unix/mio.rs
+++ b/src/event/source/unix/mio.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, io, time::Duration};
+use std::{io, time::Duration};
 
 use mio::{unix::SourceFd, Events, Interest, Poll, Token};
 use signal_hook_mio::v1_0::Signals;
@@ -6,7 +6,7 @@ use signal_hook_mio::v1_0::Signals;
 #[cfg(feature = "event-stream")]
 use crate::event::sys::Waker;
 use crate::event::{
-    internal::InternalEvent, source::EventSource, sys::unix::parse::parse_event,
+    internal::InternalEvent, source::unix::parser::Parser, source::EventSource,
     timeout::PollTimeout, Event,
 };
 use crate::terminal::sys::file_descriptor::{tty_fd, FileDesc};
@@ -159,72 +159,3 @@ impl EventSource for UnixInternalEventSource {
     }
 }
 
-//
-// Following `Parser` structure exists for two reasons:
-//
-//  * mimic anes Parser interface
-//  * move the advancing, parsing, ... stuff out of the `try_read` method
-//
-#[derive(Debug)]
-struct Parser {
-    buffer: Vec<u8>,
-    internal_events: VecDeque<InternalEvent>,
-}
-
-impl Default for Parser {
-    fn default() -> Self {
-        Parser {
-            // This buffer is used for -> 1 <- ANSI escape sequence. Are we
-            // aware of any ANSI escape sequence that is bigger? Can we make
-            // it smaller?
-            //
-            // Probably not worth spending more time on this as "there's a plan"
-            // to use the anes crate parser.
-            buffer: Vec::with_capacity(256),
-            // TTY_BUFFER_SIZE is 1_024 bytes. How many ANSI escape sequences can
-            // fit? What is an average sequence length? Let's guess here
-            // and say that the average ANSI escape sequence length is 8 bytes. Thus
-            // the buffer size should be 1024/8=128 to avoid additional allocations
-            // when processing large amounts of data.
-            //
-            // There's no need to make it bigger, because when you look at the `try_read`
-            // method implementation, all events are consumed before the next TTY_BUFFER
-            // is processed -> events pushed.
-            internal_events: VecDeque::with_capacity(128),
-        }
-    }
-}
-
-impl Parser {
-    fn advance(&mut self, buffer: &[u8], more: bool) {
-        for (idx, byte) in buffer.iter().enumerate() {
-            let more = idx + 1 < buffer.len() || more;
-
-            self.buffer.push(*byte);
-
-            match parse_event(&self.buffer, more) {
-                Ok(Some(ie)) => {
-                    self.internal_events.push_back(ie);
-                    self.buffer.clear();
-                }
-                Ok(None) => {
-                    // Event can't be parsed, because we don't have enough bytes for
-                    // the current sequence. Keep the buffer and process next bytes.
-                }
-                Err(_) => {
-                    // Event can't be parsed (not enough parameters, parameter is not a number, ...).
-                    // Clear the buffer and continue with another sequence.
-                    self.buffer.clear();
-                }
-            }
-        }
-    }
-}
-
-impl Iterator for Parser {
-    type Item = InternalEvent;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.internal_events.pop_front()
-    }
-}

--- a/src/event/source/unix/parser.rs
+++ b/src/event/source/unix/parser.rs
@@ -1,19 +1,35 @@
 //! Streaming wrapper around [`parse_event`] used by the unix event sources.
 //!
-//! [`parse_event`] is stateless: each call sees a single ANSI escape candidate. The
-//! [`Parser`] accumulates bytes across `read()` boundaries until a full sequence has been
+//! [`parse_event`] is stateless: each call sees a single ANSI escape candidate.
+//! The [`Parser`] accumulates bytes across `read()` boundaries until a full sequence has been
 //! recognised, then emits the resulting [`InternalEvent`]s to its caller.
+//!
+//! [`Parser`] also enforces [`crate::event::BracketedPasteLimits`], aborting an inflight
+//! bracketed paste that exceeds the configured limits.
 
 use std::collections::VecDeque;
+#[cfg(feature = "bracketed-paste")]
+use std::time::Instant;
 
 use crate::event::internal::InternalEvent;
 use crate::event::sys::unix::parse::parse_event;
+#[cfg(feature = "bracketed-paste")]
+use crate::event::{bracketed_paste_limits, BracketedPasteLimits, Event, PasteAbortReason};
+
+#[cfg(feature = "bracketed-paste")]
+const BRACKETED_PASTE_START: &[u8] = b"\x1B[200~";
 
 /// Streams bytes from a tty into a queue of parsed [`InternalEvent`]s.
 #[derive(Debug)]
 pub(crate) struct Parser {
+    /// Bytes belonging to a single in-progress ANSI escape sequence.
     buffer: Vec<u8>,
+    /// Events ready for the caller to consume.
     internal_events: VecDeque<InternalEvent>,
+    /// Wall-clock instant at which the current bracketed paste began, or `None` if no
+    /// bracketed paste is in progress.
+    #[cfg(feature = "bracketed-paste")]
+    paste_started_at: Option<Instant>,
 }
 
 impl Default for Parser {
@@ -36,21 +52,40 @@ impl Default for Parser {
             // method implementation, all events are consumed before the next TTY_BUFFER
             // is processed -> events pushed.
             internal_events: VecDeque::with_capacity(128),
+            #[cfg(feature = "bracketed-paste")]
+            paste_started_at: None,
         }
     }
 }
 
 impl Parser {
     pub(crate) fn advance(&mut self, buffer: &[u8], more: bool) {
+        // Hoist the atomics-backed limit read out of the per-byte hot path. Once limits
+        // are installed they tend to stay installed for the lifetime of the application,
+        // and a single `read()` typically delivers a contiguous burst of bytes.
+        #[cfg(feature = "bracketed-paste")]
+        let limits = bracketed_paste_limits();
         for (idx, byte) in buffer.iter().enumerate() {
             let more = idx + 1 < buffer.len() || more;
 
             self.buffer.push(*byte);
 
+            #[cfg(feature = "bracketed-paste")]
+            self.update_paste_tracking();
+
+            #[cfg(feature = "bracketed-paste")]
+            if self.maybe_abort_paste(limits) {
+                continue;
+            }
+
             match parse_event(&self.buffer, more) {
                 Ok(Some(ie)) => {
                     self.internal_events.push_back(ie);
                     self.buffer.clear();
+                    #[cfg(feature = "bracketed-paste")]
+                    {
+                        self.paste_started_at = None;
+                    }
                 }
                 Ok(None) => {
                     // Event can't be parsed, because we don't have enough bytes for
@@ -60,9 +95,73 @@ impl Parser {
                     // Event can't be parsed (not enough parameters, parameter is not a number, ...).
                     // Clear the buffer and continue with another sequence.
                     self.buffer.clear();
+                    #[cfg(feature = "bracketed-paste")]
+                    {
+                        self.paste_started_at = None;
+                    }
                 }
             }
         }
+    }
+
+    /// Records the start instant the moment the bracketed-paste prefix is fully buffered.
+    ///
+    /// The instant is captured unconditionally (even when no limits are configured) so
+    /// that limits installed mid-paste still see the true paste start. This costs one
+    /// [`Instant::now`] call per paste, which is negligible compared to the user-driven
+    /// cadence of paste events.
+    #[cfg(feature = "bracketed-paste")]
+    fn update_paste_tracking(&mut self) {
+        if self.paste_started_at.is_none()
+            && self.buffer.len() == BRACKETED_PASTE_START.len()
+            && self.buffer == BRACKETED_PASTE_START
+        {
+            self.paste_started_at = Some(Instant::now());
+        }
+    }
+
+    /// If an inflight bracketed paste exceeds `limits`, hand the accumulated buffer off
+    /// to the caller as an [`Event::PasteAborted`] and reset the parser state. Returns
+    /// `true` when an abort fired, so the caller can skip the normal `parse_event`
+    /// dispatch for the byte that triggered it.
+    ///
+    /// `limits` is taken as a parameter (rather than re-read here) so the atomics behind
+    /// [`bracketed_paste_limits`] are read at most once per [`Self::advance`] call rather
+    /// than once per byte.
+    #[cfg(feature = "bracketed-paste")]
+    fn maybe_abort_paste(&mut self, limits: BracketedPasteLimits) -> bool {
+        let Some(started_at) = self.paste_started_at else {
+            return false;
+        };
+        debug_assert!(
+            self.buffer.starts_with(BRACKETED_PASTE_START),
+            "buffer must start with the bracketed-paste prefix whenever paste_started_at is set",
+        );
+        let reason = if limits
+            .max_bytes
+            .map_or(false, |cap| self.buffer.len() > cap)
+        {
+            PasteAbortReason::SizeLimit
+        } else if limits
+            .max_duration
+            .map_or(false, |cap| started_at.elapsed() > cap)
+        {
+            PasteAbortReason::Timeout
+        } else {
+            return false;
+        };
+        // Move the buffered bytes (including the `\x1B[200~` prefix) into the event so the
+        // caller can salvage them if desired. The buffer is replaced with a fresh
+        // allocation of the original capacity so subsequent escape sequences don't pay
+        // reallocation costs.
+        let buffered_bytes = std::mem::replace(&mut self.buffer, Vec::with_capacity(256));
+        self.paste_started_at = None;
+        self.internal_events
+            .push_back(InternalEvent::Event(Event::PasteAborted {
+                reason,
+                buffered_bytes,
+            }));
+        true
     }
 }
 
@@ -71,5 +170,156 @@ impl Iterator for Parser {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.internal_events.pop_front()
+    }
+}
+
+#[cfg(all(test, feature = "bracketed-paste"))]
+mod tests {
+    use std::time::Duration;
+
+    use parking_lot::{Mutex, MutexGuard};
+
+    use crate::event::{
+        bracketed_paste_limits, internal::InternalEvent, set_bracketed_paste_limits,
+        BracketedPasteLimits, Event, PasteAbortReason,
+    };
+
+    use super::Parser;
+
+    /// The limits are process-global, so tests that touch them must run serially.
+    ///
+    /// This mutex is taken at the start of every limits-affecting test and held
+    /// until the previous limits have been restored.
+    static LIMITS_LOCK: Mutex<()> = Mutex::new(());
+
+    struct LimitGuard<'a> {
+        previous: BracketedPasteLimits,
+        _serialize: MutexGuard<'a, ()>,
+    }
+
+    impl LimitGuard<'_> {
+        fn new(limits: BracketedPasteLimits) -> Self {
+            let serialize = LIMITS_LOCK.lock();
+            let previous = bracketed_paste_limits();
+            set_bracketed_paste_limits(limits);
+            LimitGuard {
+                previous,
+                _serialize: serialize,
+            }
+        }
+    }
+
+    impl Drop for LimitGuard<'_> {
+        fn drop(&mut self) {
+            set_bracketed_paste_limits(self.previous);
+        }
+    }
+
+    fn drain(parser: &mut Parser) -> Vec<InternalEvent> {
+        std::iter::from_fn(|| parser.next()).collect()
+    }
+
+    #[test]
+    fn completes_paste_within_size_limit() {
+        let _guard = LimitGuard::new(BracketedPasteLimits {
+            max_duration: None,
+            max_bytes: Some(1024),
+        });
+        let mut parser = Parser::default();
+        parser.advance(b"\x1B[200~hello\x1B[201~", false);
+        assert_eq!(
+            drain(&mut parser),
+            vec![InternalEvent::Event(Event::Paste("hello".into()))]
+        );
+    }
+
+    #[test]
+    fn aborts_paste_when_size_limit_exceeded() {
+        let _guard = LimitGuard::new(BracketedPasteLimits {
+            max_duration: None,
+            // Six bytes for the prefix plus one byte of payload is the smallest
+            // overflow we can observe.
+            max_bytes: Some(6),
+        });
+        let mut parser = Parser::default();
+        parser.advance(b"\x1B[200~abcdef", false);
+        let events = drain(&mut parser);
+        // The first byte past the cap aborts the paste; subsequent bytes parse normally
+        // as key events (the parser has dropped its inflight paste state).
+        let (first, rest) = events.split_first().expect("at least one event");
+        let InternalEvent::Event(Event::PasteAborted {
+            reason,
+            buffered_bytes,
+        }) = first
+        else {
+            panic!("expected PasteAborted, got {first:?}");
+        };
+        assert_eq!(*reason, PasteAbortReason::SizeLimit);
+        // The aborted buffer includes the `\x1B[200~` prefix plus the byte that tripped
+        // the cap.
+        assert_eq!(buffered_bytes, b"\x1B[200~a");
+        for event in rest {
+            assert!(
+                matches!(event, InternalEvent::Event(Event::Key(_))),
+                "expected Key event after abort, got {event:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn aborts_paste_when_timeout_exceeded() {
+        let _guard = LimitGuard::new(BracketedPasteLimits {
+            max_duration: Some(Duration::from_millis(1)),
+            max_bytes: None,
+        });
+        let mut parser = Parser::default();
+        parser.advance(b"\x1B[200~a", false);
+        std::thread::sleep(Duration::from_millis(20));
+        // The next byte after the timeout has elapsed should trip the abort.
+        parser.advance(b"b", false);
+        let events = drain(&mut parser);
+        assert!(
+            matches!(
+                events.as_slice(),
+                [InternalEvent::Event(Event::PasteAborted {
+                    reason: PasteAbortReason::Timeout,
+                    ..
+                })]
+            ),
+            "unexpected events: {events:?}",
+        );
+    }
+
+    #[test]
+    fn parser_recovers_to_normal_input_after_abort() {
+        let _guard = LimitGuard::new(BracketedPasteLimits {
+            max_duration: None,
+            max_bytes: Some(8),
+        });
+        let mut parser = Parser::default();
+        // Trigger an abort, then feed a complete ArrowLeft escape sequence.
+        parser.advance(b"\x1B[200~xxxxxxxx", false);
+        parser.advance(b"\x1B[D", false);
+        let events = drain(&mut parser);
+        assert!(
+            matches!(events[0], InternalEvent::Event(Event::PasteAborted { .. })),
+            "first event must be PasteAborted, got {:?}",
+            events.first(),
+        );
+        assert!(
+            matches!(events[1], InternalEvent::Event(Event::Key(_))),
+            "second event must be a key event, got {:?}",
+            events.get(1),
+        );
+    }
+
+    #[test]
+    fn limits_default_unbounded_preserves_old_behaviour() {
+        let _guard = LimitGuard::new(BracketedPasteLimits::default());
+        let mut parser = Parser::default();
+        // Feed 64 KiB of payload without a closing marker; nothing should be emitted.
+        parser.advance(b"\x1B[200~", false);
+        parser.advance(&vec![b'x'; 64 * 1024], false);
+        assert!(drain(&mut parser).is_empty());
     }
 }

--- a/src/event/source/unix/parser.rs
+++ b/src/event/source/unix/parser.rs
@@ -1,0 +1,75 @@
+//! Streaming wrapper around [`parse_event`] used by the unix event sources.
+//!
+//! [`parse_event`] is stateless: each call sees a single ANSI escape candidate. The
+//! [`Parser`] accumulates bytes across `read()` boundaries until a full sequence has been
+//! recognised, then emits the resulting [`InternalEvent`]s to its caller.
+
+use std::collections::VecDeque;
+
+use crate::event::internal::InternalEvent;
+use crate::event::sys::unix::parse::parse_event;
+
+/// Streams bytes from a tty into a queue of parsed [`InternalEvent`]s.
+#[derive(Debug)]
+pub(crate) struct Parser {
+    buffer: Vec<u8>,
+    internal_events: VecDeque<InternalEvent>,
+}
+
+impl Default for Parser {
+    fn default() -> Self {
+        Parser {
+            // This buffer is used for -> 1 <- ANSI escape sequence. Are we
+            // aware of any ANSI escape sequence that is bigger? Can we make
+            // it smaller?
+            //
+            // Probably not worth spending more time on this as "there's a plan"
+            // to use the anes crate parser.
+            buffer: Vec::with_capacity(256),
+            // TTY_BUFFER_SIZE is 1_024 bytes. How many ANSI escape sequences can
+            // fit? What is an average sequence length? Let's guess here
+            // and say that the average ANSI escape sequence length is 8 bytes. Thus
+            // the buffer size should be 1024/8=128 to avoid additional allocations
+            // when processing large amounts of data.
+            //
+            // There's no need to make it bigger, because when you look at the `try_read`
+            // method implementation, all events are consumed before the next TTY_BUFFER
+            // is processed -> events pushed.
+            internal_events: VecDeque::with_capacity(128),
+        }
+    }
+}
+
+impl Parser {
+    pub(crate) fn advance(&mut self, buffer: &[u8], more: bool) {
+        for (idx, byte) in buffer.iter().enumerate() {
+            let more = idx + 1 < buffer.len() || more;
+
+            self.buffer.push(*byte);
+
+            match parse_event(&self.buffer, more) {
+                Ok(Some(ie)) => {
+                    self.internal_events.push_back(ie);
+                    self.buffer.clear();
+                }
+                Ok(None) => {
+                    // Event can't be parsed, because we don't have enough bytes for
+                    // the current sequence. Keep the buffer and process next bytes.
+                }
+                Err(_) => {
+                    // Event can't be parsed (not enough parameters, parameter is not a number, ...).
+                    // Clear the buffer and continue with another sequence.
+                    self.buffer.clear();
+                }
+            }
+        }
+    }
+}
+
+impl Iterator for Parser {
+    type Item = InternalEvent;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.internal_events.pop_front()
+    }
+}

--- a/src/event/source/unix/tty.rs
+++ b/src/event/source/unix/tty.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "libc")]
 use std::os::unix::prelude::AsRawFd;
-use std::{collections::VecDeque, io, os::unix::net::UnixStream, time::Duration};
+use std::{io, os::unix::net::UnixStream, time::Duration};
 
 #[cfg(not(feature = "libc"))]
 use rustix::fd::{AsFd, AsRawFd};
@@ -13,7 +13,7 @@ use filedescriptor::{poll, pollfd, POLLIN};
 
 #[cfg(feature = "event-stream")]
 use crate::event::sys::Waker;
-use crate::event::{internal::InternalEvent, source::EventSource, sys::unix::parse::parse_event};
+use crate::event::{internal::InternalEvent, source::EventSource, source::unix::parser::Parser};
 use crate::terminal::sys::file_descriptor::{tty_fd, FileDesc};
 
 /// Holds a prototypical Waker and a receiver we can wait on when doing select().
@@ -204,75 +204,5 @@ impl EventSource for UnixInternalEventSource {
     #[cfg(feature = "event-stream")]
     fn waker(&self) -> Waker {
         self.wake_pipe.waker.clone()
-    }
-}
-
-//
-// Following `Parser` structure exists for two reasons:
-//
-//  * mimic anes Parser interface
-//  * move the advancing, parsing, ... stuff out of the `try_read` method
-//
-#[derive(Debug)]
-struct Parser {
-    buffer: Vec<u8>,
-    internal_events: VecDeque<InternalEvent>,
-}
-
-impl Default for Parser {
-    fn default() -> Self {
-        Parser {
-            // This buffer is used for -> 1 <- ANSI escape sequence. Are we
-            // aware of any ANSI escape sequence that is bigger? Can we make
-            // it smaller?
-            //
-            // Probably not worth spending more time on this as "there's a plan"
-            // to use the anes crate parser.
-            buffer: Vec::with_capacity(256),
-            // TTY_BUFFER_SIZE is 1_024 bytes. How many ANSI escape sequences can
-            // fit? What is an average sequence length? Let's guess here
-            // and say that the average ANSI escape sequence length is 8 bytes. Thus
-            // the buffer size should be 1024/8=128 to avoid additional allocations
-            // when processing large amounts of data.
-            //
-            // There's no need to make it bigger, because when you look at the `try_read`
-            // method implementation, all events are consumed before the next TTY_BUFFER
-            // is processed -> events pushed.
-            internal_events: VecDeque::with_capacity(128),
-        }
-    }
-}
-
-impl Parser {
-    fn advance(&mut self, buffer: &[u8], more: bool) {
-        for (idx, byte) in buffer.iter().enumerate() {
-            let more = idx + 1 < buffer.len() || more;
-
-            self.buffer.push(*byte);
-
-            match parse_event(&self.buffer, more) {
-                Ok(Some(ie)) => {
-                    self.internal_events.push_back(ie);
-                    self.buffer.clear();
-                }
-                Ok(None) => {
-                    // Event can't be parsed, because we don't have enough bytes for
-                    // the current sequence. Keep the buffer and process next bytes.
-                }
-                Err(_) => {
-                    // Event can't be parsed (not enough parameters, parameter is not a number, ...).
-                    // Clear the buffer and continue with another sequence.
-                    self.buffer.clear();
-                }
-            }
-        }
-    }
-}
-
-impl Iterator for Parser {
-    type Item = InternalEvent;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.internal_events.pop_front()
     }
 }


### PR DESCRIPTION
Provides an opt-in mitigation for #1060.

# Summary

Adds an opt-in `BracketedPasteLimits` API that bounds inflight bracketed
pastes by wall-clock duration and/or accumulated bytes. When either bound
is exceeded, the parser hands the buffered bytes back to the caller as a new
`Event::PasteAborted { reason, buffered_bytes }` event and resumes normal
parsing.

Without this, an orphaned `\x1B[200~` will cause crossterm to swallow every
subsequent byte from the tty indefinitely. See #1060 for full discussion.

Both new limit fields default to `None`, so behavior is unchanged for existing callers.

# Changes

This PR is split into two commits to keep review manageable.

  0. ed36c4e
     Pure code motion. `src/event/source/unix/{tty,mio}.rs` each carried
     identical copies of a `Parser` struct. This deduplicates the code by extracting
     the implementation to a new shared `src/event/source/unix/parser` module.
     No effect on behavior or public API.

  1. 0695013
     The actual fix. Adds:

       - `pub struct BracketedPasteLimits { max_duration, max_bytes }`
       - `pub fn set_bracketed_paste_limits(BracketedPasteLimits)`
       - `pub fn bracketed_paste_limits() -> BracketedPasteLimits`
       - `pub enum PasteAbortReason { Timeout, SizeLimit }`
       - new `Event::PasteAborted { reason, buffered_bytes: Vec<u8> }` variant

     The limits storage lives behind two relaxed atomics (`AtomicU64` for
     duration in millis, `AtomicUsize` for bytes, with sentinel values for
     `None`). These are snapshotted once per read and threaded into the per-byte abort check.

     When an abort fires, the accumulated buffer (including the
     `ESC [ 200 ~` prefix) is moved into the event so the caller can
     salvage it; the parser's buffer is replaced with a fresh
     `Vec::with_capacity(256)` to preserve the original allocation
     behaviour for subsequent escape sequences.

# API surface

```rust
use std::time::Duration;
use crossterm::event::{set_bracketed_paste_limits, BracketedPasteLimits};

set_bracketed_paste_limits(BracketedPasteLimits {
    max_duration: Some(Duration::from_secs(5)),
    max_bytes: Some(1024 * 1024),
});
```

After this, an inflight paste that runs longer than 5s or exceeds 1 MiB
will be aborted:

```rust
match event::read()? {
    Event::PasteAborted { reason, buffered_bytes } => {
        log::warn!("paste aborted ({reason:?}); recovered {} bytes", buffered_bytes.len());
    }
    Event::Paste(s) => { /* normal complete paste */ }
    ...
}
```

# Compatibility

  * Both new limit fields default to `None`, so the parser behaves
    identically to today's unbounded accumulator unless the caller opts in.
  * `Event::PasteAborted` is a new variant gated behind the existing
    `bracketed-paste` feature flag, so it lands in the same conditional
    compilation region as `Event::Paste` and only affects callers who have
    that feature enabled.
    - Still, since `Event` is not marked `#[non_exhaustive]`, this is
      a **breaking change** and warrants a version bump.
  * No new runtime dependencies.

# Tests

5 new tests in `src/event/source/unix/parser.rs::tests`, all gated on
`feature = "bracketed-paste"`:

  - `completes_paste_within_size_limit`
  - `aborts_paste_when_size_limit_exceeded`
  - `aborts_paste_when_timeout_exceeded`
  - `parser_recovers_to_normal_input_after_abort`
  - `limits_default_unbounded_preserves_old_behaviour`

The limits are process-global, so the tests serialize on an internal
`parking_lot::Mutex` and restore the previously-installed limits on drop
to avoid cross-test interference.

# E2E reproduction

I wrote a standalone end-to-end reproduction that uses only the public
crossterm API: it opens a pty, forks, has the child enable bracketed paste
and drain `event::read()` into a log, then has the parent write `\x1B[200~`
into the master fd followed by plain keystrokes without ever sending the
close marker.

<details><summary>Reproduction code</summary>

```rust
//! End-to-end reproduction of the bracketed-paste hang in crossterm 0.29.0.
//!
//! Setup:
//!   * The parent process opens a PTY pair, forks, and the child re-execs
//!     itself with `child` as the first argument. The child's stdin / stdout /
//!     stderr are wired to the slave end of the PTY, so the child sees a real
//!     terminal and crossterm exercises the same code path it would in
//!     production.
//!   * The child enables bracketed paste, switches into raw mode, and
//!     `event::read`s in a loop for a few seconds. Every event it observes is
//!     appended to a log file at `/tmp/ct-repro-events.log` (chosen so the
//!     parent can read it back without interleaving with PTY traffic).
//!   * The parent writes the *opening* bracketed-paste marker `ESC [ 200 ~`
//!     into the master end, waits briefly, then writes a sequence of plain
//!     keystrokes (`abcdef`). It never writes the closing `ESC [ 201 ~`
//!     marker, simulating a terminal / multiplexer that dropped it.
//!   * After a few seconds the parent reaps the child, prints the contents of
//!     the log file, and reports whether any keystroke events were observed.
//!
//! Expected result on crossterm 0.29.0 (no limits): the log file is empty
//! (the child never received an event because every byte got swallowed by the
//! orphan-paste buffer).
//!
//! Expected result on a build with bracketed-paste limits installed: the log
//! file contains a `PasteAborted` event followed by `Key` events for each
//! plain keystroke.

use std::env;
use std::ffi::CString;
use std::fs::{File, OpenOptions};
use std::io::{Read, Write};
use std::os::fd::{AsRawFd, OwnedFd};
use std::os::unix::io::FromRawFd;
use std::path::Path;
use std::process::ExitCode;
use std::thread;
use std::time::{Duration, Instant};

use crossterm::event::{
    self, DisableBracketedPaste, EnableBracketedPaste, Event, KeyCode, KeyEventKind,
};
use crossterm::execute;
use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
use nix::pty::{openpty, OpenptyResult};
use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
use nix::unistd::{dup2, execv, fork, ForkResult, Pid};

const EVENT_LOG_PATH: &str = "/tmp/ct-repro-events.log";
const CHILD_RUN_DURATION: Duration = Duration::from_secs(4);
const PARENT_WEDGE_DELAY: Duration = Duration::from_millis(250);
const PARENT_KEYS_DELAY: Duration = Duration::from_millis(500);

fn main() -> ExitCode {
    let args: Vec<String> = env::args().collect();
    if args.get(1).map(String::as_str) == Some("child") {
        match run_child() {
            Ok(()) => ExitCode::SUCCESS,
            Err(e) => {
                let _ = writeln!(std::io::stderr(), "child error: {e}");
                ExitCode::from(1)
            }
        }
    } else {
        match run_parent() {
            Ok(code) => code,
            Err(e) => {
                eprintln!("parent error: {e}");
                ExitCode::from(1)
            }
        }
    }
}

/// Parent: opens a PTY, forks, drives the master end, reports on the log.
fn run_parent() -> Result<ExitCode, Box<dyn std::error::Error>> {
    // Clean up any previous run so we never accidentally read stale events.
    let _ = std::fs::remove_file(EVENT_LOG_PATH);

    let OpenptyResult { master, slave } = openpty(None, None)?;
    let master: OwnedFd = master;
    let slave: OwnedFd = slave;

    let self_exe = env::current_exe()?;
    let exe_c = CString::new(self_exe.as_os_str().to_string_lossy().as_bytes())?;
    let arg_c = CString::new("child")?;

    // SAFETY: We only call async-signal-safe functions in the child branch
    // (dup2, execv). No allocations, no Rust-level locks acquired between fork
    // and exec.
    match unsafe { fork()? } {
        ForkResult::Child => {
            // Wire the slave end to stdin/stdout/stderr.
            let slave_raw = slave.as_raw_fd();
            dup2(slave_raw, 0)?;
            dup2(slave_raw, 1)?;
            dup2(slave_raw, 2)?;
            // Close the master / slave fds we no longer need.
            drop(master);
            drop(slave);
            execv(&exe_c, &[&exe_c, &arg_c])?;
            unreachable!()
        }
        ForkResult::Parent { child } => {
            drop(slave);
            drive_parent(master, child)
        }
    }
}

fn drive_parent(master: OwnedFd, child: Pid) -> Result<ExitCode, Box<dyn std::error::Error>> {
    // SAFETY: nix's OwnedFd owns the raw fd; converting to File transfers
    // ownership for the lifetime of `file`.
    let master_fd = master.as_raw_fd();
    let mut master_writer = unsafe { File::from_raw_fd(master_fd) };
    // Prevent the OwnedFd's drop from closing the fd a second time.
    std::mem::forget(master);

    // Drain the PTY output in a background thread so the slave's write buffer
    // never fills up and blocks the child. We discard the bytes; the
    // interesting signal is the event log.
    let drain_fd = master_writer.try_clone()?;
    let drainer = thread::spawn(move || {
        let mut f = drain_fd;
        let mut buf = [0u8; 1024];
        loop {
            match f.read(&mut buf) {
                Ok(0) | Err(_) => break,
                Ok(_) => {}
            }
        }
    });

    // Wait for the child to install its event loop before sending anything.
    thread::sleep(PARENT_WEDGE_DELAY);

    // 0. Open the paste without ever closing it.
    master_writer.write_all(b"\x1B[200~")?;
    master_writer.flush()?;

    // 1. Pretend the user types real keys after the paste was "interrupted".
    thread::sleep(PARENT_KEYS_DELAY);
    master_writer.write_all(b"abcdef")?;
    master_writer.flush()?;

    // 2. Give the child time to (try to) process the input.
    thread::sleep(CHILD_RUN_DURATION);

    // 3. Reap the child. It exits on its own after its run duration elapses;
    // if it's wedged, send SIGTERM so we don't hang forever.
    let status = waitpid(child, Some(WaitPidFlag::WNOHANG))?;
    if matches!(status, WaitStatus::StillAlive) {
        nix::sys::signal::kill(child, nix::sys::signal::Signal::SIGTERM)?;
        waitpid(child, None)?;
    }

    // 4. Closing the master end will end the drainer thread.
    drop(master_writer);
    let _ = drainer.join();

    // 5. Report.
    println!("===== ct-repro report =====");
    let log = std::fs::read_to_string(EVENT_LOG_PATH).unwrap_or_default();
    if log.is_empty() {
        println!("event log is EMPTY -- the parser swallowed every byte we sent.");
        println!("the child never observed a single Event::Key for 'abcdef'.");
        println!("this is the bug: an orphan bracketed-paste prefix wedges crossterm.");
        Ok(ExitCode::from(2))
    } else {
        println!("event log:\n{log}");
        let key_lines = log.lines().filter(|l| l.contains("Key(")).count();
        let abort_lines = log.lines().filter(|l| l.contains("PasteAborted")).count();
        println!(
            "summary: {key_lines} Key event(s), {abort_lines} PasteAborted event(s)",
        );
        Ok(ExitCode::SUCCESS)
    }
}

/// Child: enables bracketed paste, drains events into a log file.
fn run_child() -> Result<(), Box<dyn std::error::Error>> {
    let mut log = OpenOptions::new()
        .create(true)
        .append(true)
        .truncate(false)
        .open(Path::new(EVENT_LOG_PATH))?;

    enable_raw_mode()?;
    let mut stdout = std::io::stdout();
    execute!(stdout, EnableBracketedPaste)?;

    let deadline = Instant::now() + CHILD_RUN_DURATION;
    while Instant::now() < deadline {
        // Bound each poll so we re-check the deadline; otherwise a wedged
        // parser would block here forever and we'd never write our log.
        if event::poll(Duration::from_millis(100))? {
            let ev = event::read()?;
            writeln!(log, "{:?}", ev)?;
            log.flush()?;
            if let Event::Key(k) = ev {
                if k.kind == KeyEventKind::Press && k.code == KeyCode::Char('q') {
                    break;
                }
            }
        }
    }

    let _ = execute!(stdout, DisableBracketedPaste);
    let _ = disable_raw_mode();
    Ok(())
}
```
</details>

Output against the two builds:

  * crossterm 0.29.0 (c02a080): event log is empty, no `Key` events
    observed for 4 seconds, application is wedged.
  * this PR (with limits installed): 1 `PasteAborted` event (containing
    `[27, 91, 50, 48, 48, 126, 97]`, i.e. `ESC [ 200 ~ a`) followed by
    `Key('b' .. 'f')`. The parser recovered cleanly and even surfaced the
    byte the user happened to type before the abort fired.

# Verification per commit

  * `cargo test --all-features --lib` at the refactor commit: 112 passed.
  * `cargo test --all-features --lib` at this commit: 117 passed (5 new).
  * `cargo fmt --all -- --check`: clean.
  * `cargo build --all-features`: no new warnings.
  * `cargo build --no-default-features`: one pre-existing warning
    (`method 'read' is never used` on `FileDesc`) that reproduces on
    `upstream/master` and is unrelated to this PR.

# CHANGELOG

A single entry under `# Unreleased / ## Added`, following the existing
single-line bullet convention.
