### PR TITLE
fix(cursor): write CSI 6n query to TTY when stdout is redirected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Fixed 🐛
+
+- `cursor::position()` on Unix now writes the CSI 6n query to stderr or `/dev/tty` when stdout is redirected, so it no longer corrupts piped output and works when stdout is not a TTY (#652)
+
 # Version 0.29
 
 ## Added ⭐

--- a/src/cursor/sys/unix.rs
+++ b/src/cursor/sys/unix.rs
@@ -1,4 +1,5 @@
 use std::{
+    fs::OpenOptions,
     io::{self, Error, ErrorKind, Write},
     time::Duration,
 };
@@ -7,6 +8,16 @@ use crate::{
     event::{filter::CursorPositionFilter, poll_internal, read_internal, InternalEvent},
     terminal::{disable_raw_mode, enable_raw_mode, sys::is_raw_mode_enabled},
 };
+
+#[cfg(feature = "libc")]
+fn fd_is_tty(fd: libc::c_int) -> bool {
+    unsafe { libc::isatty(fd) == 1 }
+}
+
+#[cfg(not(feature = "libc"))]
+fn fd_is_tty<F: rustix::fd::AsFd>(fd: F) -> bool {
+    rustix::termios::isatty(fd)
+}
 
 /// Returns the cursor position (column, row).
 ///
@@ -29,11 +40,45 @@ fn read_position() -> io::Result<(u16, u16)> {
     pos
 }
 
+// `ESC [ 6 n` device status report: ask terminal for cursor position.
+// Must reach the controlling terminal even when stdout/stderr are redirected,
+// otherwise the query is piped to the redirect target (see issue #652).
+fn write_cursor_query(buf: &[u8]) -> io::Result<()> {
+    #[cfg(feature = "libc")]
+    let (stdout_is_tty, stderr_is_tty) = (
+        fd_is_tty(libc::STDOUT_FILENO),
+        fd_is_tty(libc::STDERR_FILENO),
+    );
+    #[cfg(not(feature = "libc"))]
+    let (stdout_is_tty, stderr_is_tty) = (
+        fd_is_tty(rustix::stdio::stdout()),
+        fd_is_tty(rustix::stdio::stderr()),
+    );
+
+    if stdout_is_tty {
+        let stdout = io::stdout();
+        let mut out = stdout.lock();
+        out.write_all(buf)?;
+        out.flush()?;
+        return Ok(());
+    }
+
+    if stderr_is_tty {
+        let stderr = io::stderr();
+        let mut out = stderr.lock();
+        out.write_all(buf)?;
+        out.flush()?;
+        return Ok(());
+    }
+
+    let mut tty = OpenOptions::new().write(true).open("/dev/tty")?;
+    tty.write_all(buf)?;
+    tty.flush()?;
+    Ok(())
+}
+
 fn read_position_raw() -> io::Result<(u16, u16)> {
-    // Use `ESC [ 6 n` to and retrieve the cursor position.
-    let mut stdout = io::stdout();
-    stdout.write_all(b"\x1B[6n")?;
-    stdout.flush()?;
+    write_cursor_query(b"\x1B[6n")?;
 
     loop {
         match poll_internal(Some(Duration::from_millis(2000)), &CursorPositionFilter) {


### PR DESCRIPTION
## Summary

Fixes #652.

`cursor::position()` on Unix wrote the `ESC [ 6 n` Device Status Report query to stdout. When stdout is piped to another program (e.g. `prog | rev`), the escape sequence went into the pipe instead of the terminal, so the terminal never responded and the call hung until the 2s timeout. The terminal's reply also corrupted the piped output.

## Change

`write_cursor_query` picks the first available TTY for the query, in order:

1. stdout (preserved as default behavior when not redirected)
2. stderr
3. `/dev/tty`

The response is already read via `tty_fd()`, which falls back to `/dev/tty` when stdin is not a TTY, so the read side already worked — only the write side needed fixing.

`rustix::termios::isatty` is used for the TTY check (or `libc::isatty` under the `libc` feature). No new dependencies. MSRV 1.63 preserved (avoided `std::io::IsTerminal`, stable in 1.70).

## Test plan

- [x] `cargo build` (default features)
- [x] `cargo build --features libc`
- [x] `cargo build --no-default-features --features events`
- [ ] Manual: run a small binary that calls `crossterm::cursor::position()` with stdout piped to `rev` — confirm the call returns the cursor position instead of corrupting the pipe / timing out.
- [ ] Manual: same binary run normally in a terminal — confirm behavior unchanged.