### PR TITLE
docs: fix typo "corresponsing" -> "corresponding" in clipboard.rs

### DIFF
--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -70,7 +70,7 @@ pub struct ClipboardSelection(
 );
 
 impl ClipboardSelection {
-    /// Returns a String corresponsing to the "Pc" parameter of the OSC52
+    /// Returns a String corresponding to the "Pc" parameter of the OSC52
     /// sequence.
     fn to_osc52_pc(&self) -> String {
         self.0.iter().map(Into::<char>::into).collect()


### PR DESCRIPTION
Fix a small typo in a doc comment in `src/clipboard.rs`.

Line 73: `corresponsing` -> `corresponding`

```rust
// Before
/// Returns a String corresponsing to the "Pc" parameter of the OSC52

// After
/// Returns a String corresponding to the "Pc" parameter of the OSC52
```