### PR TITLE
Compile on targets that are neither unix nor windows

### DIFF
--- a/src/cursor/sys.rs
+++ b/src/cursor/sys.rs
@@ -1,5 +1,8 @@
 //! This module provides platform related functions.
 
+#[cfg(not(any(unix, windows)))]
+#[cfg(feature = "events")]
+pub use self::other::position;
 #[cfg(unix)]
 #[cfg(feature = "events")]
 pub use self::unix::position;
@@ -18,3 +21,7 @@ pub(crate) mod windows;
 #[cfg(unix)]
 #[cfg(feature = "events")]
 pub(crate) mod unix;
+
+#[cfg(not(any(unix, windows)))]
+#[cfg(feature = "events")]
+pub(crate) mod other;

--- a/src/cursor/sys/other.rs
+++ b/src/cursor/sys/other.rs
@@ -1,0 +1,11 @@
+//! Stub for targets that are neither unix nor windows (e.g. wasm): there is
+//! no terminal to query, so the cursor position is unavailable.
+
+use std::io;
+
+pub fn position() -> io::Result<(u16, u16)> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "cursor position is not available on this platform",
+    ))
+}

--- a/src/event/filter.rs
+++ b/src/event/filter.rs
@@ -59,6 +59,11 @@ impl Filter for EventFilter {
     fn eval(&self, _: &InternalEvent) -> bool {
         true
     }
+
+    #[cfg(not(any(unix, windows)))]
+    fn eval(&self, _: &InternalEvent) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/src/event/internal.rs
+++ b/src/event/internal.rs
@@ -68,6 +68,8 @@ where
 #[derive(Debug, PartialOrd, PartialEq, Hash, Clone, Eq)]
 pub(crate) enum InternalEvent {
     /// An event.
+    // Never constructed on targets without an event source.
+    #[cfg_attr(not(any(unix, windows)), allow(dead_code))]
     Event(Event),
     /// A cursor position (`col`, `row`).
     #[cfg(unix)]

--- a/src/event/read.rs
+++ b/src/event/read.rs
@@ -23,7 +23,12 @@ impl Default for InternalEventReader {
         let source = WindowsEventSource::new();
         #[cfg(unix)]
         let source = UnixInternalEventSource::new();
+        // There is no event source on other targets; `poll` reports the
+        // missing reader as an error.
+        #[cfg(not(any(unix, windows)))]
+        let source: Option<Box<dyn EventSource>> = None;
 
+        #[cfg(any(unix, windows))]
         let source = source.ok().map(|x| Box::new(x) as Box<dyn EventSource>);
 
         InternalEventReader {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -114,6 +114,11 @@ pub fn is_raw_mode_enabled() -> io::Result<bool> {
     {
         sys::is_raw_mode_enabled()
     }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        sys::is_raw_mode_enabled()
+    }
 }
 
 /// Enables raw mode.

--- a/src/terminal/sys.rs
+++ b/src/terminal/sys.rs
@@ -1,5 +1,12 @@
 //! This module provides platform related functions.
 
+#[cfg(not(any(unix, windows)))]
+#[cfg(feature = "events")]
+pub use self::other::supports_keyboard_enhancement;
+#[cfg(not(any(unix, windows)))]
+pub(crate) use self::other::{
+    disable_raw_mode, enable_raw_mode, is_raw_mode_enabled, size, window_size,
+};
 #[cfg(unix)]
 #[cfg(feature = "events")]
 pub use self::unix::supports_keyboard_enhancement;
@@ -20,6 +27,9 @@ pub(crate) use self::windows::{
 
 #[cfg(windows)]
 mod windows;
+
+#[cfg(not(any(unix, windows)))]
+mod other;
 
 #[cfg(unix)]
 pub mod file_descriptor;

--- a/src/terminal/sys/other.rs
+++ b/src/terminal/sys/other.rs
@@ -1,0 +1,39 @@
+//! Stubs for targets that are neither unix nor windows (e.g. wasm): the crate
+//! compiles, and terminal control reports `Unsupported` at runtime.
+
+use std::io;
+
+use crate::terminal::WindowSize;
+
+pub(crate) fn is_raw_mode_enabled() -> io::Result<bool> {
+    Err(unsupported())
+}
+
+pub(crate) fn enable_raw_mode() -> io::Result<()> {
+    Err(unsupported())
+}
+
+pub(crate) fn disable_raw_mode() -> io::Result<()> {
+    Err(unsupported())
+}
+
+pub(crate) fn size() -> io::Result<(u16, u16)> {
+    Err(unsupported())
+}
+
+pub(crate) fn window_size() -> io::Result<WindowSize> {
+    Err(unsupported())
+}
+
+/// There is no terminal to probe on these targets.
+#[cfg(feature = "events")]
+pub fn supports_keyboard_enhancement() -> io::Result<bool> {
+    Ok(false)
+}
+
+fn unsupported() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Unsupported,
+        "terminal control is not supported on this platform",
+    )
+}


### PR DESCRIPTION
Downstream crates want the event types and ANSI commands on targets like wasm32-unknown-unknown, where no terminal exists. Neutral cfg arms stub the platform layer: terminal control and the cursor position query return ErrorKind::Unsupported, supports_keyboard_enhancement answers false, and the event reader starts without a source, so poll reports the missing reader. The event-stream feature remains unavailable on these targets.