### PR TITLE
fix(style): don't emit a bare CSI m when colors are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 ## Fixed 🐛
 
+- Fix color commands emitting a bare `CSI m` when colors are disabled via
+  `NO_COLOR`, which reset every attribute instead of doing nothing.
+  Affects `SetForegroundColor`, `SetBackgroundColor`, `SetUnderlineColor`,
+  and `SetColors`.
 - Fix integer underflow in mouse / cursor-position parsers when coord
   bytes encoded the protocol origin (panic in debug, wrap to 65535
   in release). Affects `parse_csi_normal_mouse`, `parse_csi_rxvt_mouse`,

--- a/src/style.rs
+++ b/src/style.rs
@@ -209,6 +209,9 @@ pub struct SetForegroundColor(pub Color);
 
 impl Command for SetForegroundColor {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        if Colored::ansi_color_disabled_memoized() {
+            return Ok(());
+        }
         write!(f, csi!("{}m"), Colored::ForegroundColor(self.0))
     }
 
@@ -233,6 +236,9 @@ pub struct SetBackgroundColor(pub Color);
 
 impl Command for SetBackgroundColor {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        if Colored::ansi_color_disabled_memoized() {
+            return Ok(());
+        }
         write!(f, csi!("{}m"), Colored::BackgroundColor(self.0))
     }
 
@@ -257,6 +263,9 @@ pub struct SetUnderlineColor(pub Color);
 
 impl Command for SetUnderlineColor {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        if Colored::ansi_color_disabled_memoized() {
+            return Ok(());
+        }
         write!(f, csi!("{}m"), Colored::UnderlineColor(self.0))
     }
 
@@ -294,6 +303,9 @@ pub struct SetColors(pub Colors);
 
 impl Command for SetColors {
     fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        if Colored::ansi_color_disabled_memoized() {
+            return Ok(());
+        }
         // Writing both foreground and background colors in one command resulted in about 20% more
         // FPS (20 to 24 fps) on a fullscreen (171x51) app that writes every cell with a different
         // foreground and background color, compared to separately using the SetForegroundColor and

--- a/tests/no_color.rs
+++ b/tests/no_color.rs
@@ -1,0 +1,34 @@
+//! `NO_COLOR` is read once per process, so this lives in its own test binary.
+
+use crossterm::style::{
+    Attribute, Color, Colors, SetAttribute, SetBackgroundColor, SetColors, SetForegroundColor,
+};
+use crossterm::Command;
+
+fn ansi_of(command: &impl Command) -> String {
+    let mut ansi = String::new();
+    command.write_ansi(&mut ansi).unwrap();
+    ansi
+}
+
+#[test]
+fn disabled_colors_emit_nothing_and_keep_attributes() {
+    unsafe { std::env::set_var("NO_COLOR", "1") };
+
+    // A bare `CSI m` is the same as `CSI 0 m`, which resets every attribute,
+    // so a disabled color must not emit the wrapper at all.
+    assert_eq!(ansi_of(&SetForegroundColor(Color::Cyan)), "");
+    assert_eq!(ansi_of(&SetBackgroundColor(Color::Reset)), "");
+    assert_eq!(
+        ansi_of(&SetColors(Colors::new(Color::Cyan, Color::Reset))),
+        ""
+    );
+
+    // Attributes are not colors and must survive a neighbouring disabled color.
+    let reverse = ansi_of(&SetAttribute(Attribute::Reverse));
+    assert!(!reverse.is_empty());
+    assert_eq!(
+        format!("{}{}", reverse, ansi_of(&SetForegroundColor(Color::Cyan))),
+        reverse
+    );
+}

--- a/tests/no_color.rs
+++ b/tests/no_color.rs
@@ -1,9 +1,9 @@
 //! `NO_COLOR` is read once per process, so this lives in its own test binary.
 
+use crossterm::Command;
 use crossterm::style::{
     Attribute, Color, Colors, SetAttribute, SetBackgroundColor, SetColors, SetForegroundColor,
 };
-use crossterm::Command;
 
 fn ansi_of(command: &impl Command) -> String {
     let mut ansi = String::new();


### PR DESCRIPTION
With `NO_COLOR` set, the color commands still write the `CSI … m` wrapper around an empty payload — `Colored`'s `Display` returns early but `write_ansi` formats unconditionally. The result is `CSI m`, which is `CSI 0 m` and resets every attribute instead of doing nothing.

So any attribute next to a color is lost. ratatui draws attributes first, then colors, so a reversed line comes out as `ESC[7m ESC[m ESC[m text` instead of `ESC[7m ESC[38;5;14m ESC[49m text` — the highlight is cancelled by the next command. Found via dua-cli#238, but it hits any bold/reversed/underlined text, and only when fg/bg changes between cells, which is why it looks intermittent.

Fixed by returning early when colors are disabled. `SetColors` needs its own guard since it formats the combined sequence rather than delegating. `SetAttribute` is untouched. Test is in its own binary because the flag is memoized per process; CHANGELOG bullet added.
