### PR TITLE
fix(windows): don't feed surrogate key-up halves into the pairing

### DIFF
--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -269,6 +269,17 @@ fn parse_key_event_record(key_event: &KeyEventRecord) -> Option<WindowsKeyEvent>
                     get_char_for_key(key_event).map(KeyCode::Char)
                 }
                 surrogate @ 0xD800..=0xDFFF => {
+                    if !key_event.key_down {
+                        // The Windows emoji panel (and other KEYEVENTF_UNICODE
+                        // injectors) deliver each UTF-16 code unit as a key-down
+                        // *and* a key-up record. Feeding the key-up half into the
+                        // surrogate pairing produces broken (high, high) /
+                        // (low, low) pairs that decode to nothing, so the whole
+                        // character is silently lost. Only the key-down half
+                        // carries the surrogate forward; the key-up half is
+                        // dropped here *without* disturbing a buffered value.
+                        return None;
+                    }
                     return Some(WindowsKeyEvent::Surrogate(surrogate));
                 }
                 unicode_scalar_value => {


### PR DESCRIPTION
Fixes #1072.

The Windows emoji panel (and any `KEYEVENTF_UNICODE` injector) delivers each UTF-16 code unit of a non-BMP character as a key-down **and** a key-up record. `parse_key_event_record` forwarded the surrogate range on both, so `handle_surrogate` paired (high, high) then (low, low) — both decode errors — and the character vanished without a trace. See the issue for the raw `ReadConsoleInputW` capture demonstrating the down+up interleaving (`vk=0`).

This lets only key-down records carry a surrogate into the pairing; a key-up half returns `None` before reaching `handle_key_event`'s buffer handling, so a buffered down-half survives it and pairs with the next down-half.

Notes for review:

- The `VK_MENU` alt-code branch above also emits surrogates on key-up — **by design** (alt codes are keyup-driven) — and is deliberately untouched.
- No unit test accompanies this: `KeyEventRecord` cannot be constructed outside `crossterm_winapi` (`ControlKeyState`'s field is private), which is presumably why this file has no existing tests. Verified instead against the raw capture in the issue and end-to-end in a TUI that forwards the composed character to a PTY child (dogfooded via `[patch.crates-io]` in kt81/banto).

Happy to adjust if there's an established way to test this path.