### PR TITLE
Migrate Crossterm to the Rust 2024 edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Raise the minimum supported Rust version from 1.63 to 1.85.
 
+## Changed ⚙️
+
+- Migrate the crate to the Rust 2024 edition. This does not raise the MSRV beyond Rust 1.85.
+
 ## Fixed 🐛
 
 - Fix integer underflow in mouse / cursor-position parsers when coord

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 keywords = ["event", "color", "cli", "input", "terminal"]
 exclude = ["target", "Cargo.lock"]
 readme = "README.md"
-edition = "2021"
+edition = "2024"
 # The MSRV covers the library with no default features and with all public features enabled.
 # Development tools and examples do not independently define the crate's MSRV.
 rust-version = "1.85.0"

--- a/examples/event-poll-read.rs
+++ b/examples/event-poll-read.rs
@@ -6,7 +6,7 @@ use std::{io, time::Duration};
 
 use crossterm::{
     cursor::position,
-    event::{poll, read, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
+    event::{DisableMouseCapture, EnableMouseCapture, Event, KeyCode, poll, read},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode},
 };

--- a/examples/event-read.rs
+++ b/examples/event-read.rs
@@ -5,13 +5,13 @@
 use std::io;
 
 use crossterm::event::{
-    poll, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags, poll,
 };
 use crossterm::{
     cursor::position,
     event::{
-        read, DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
-        EnableFocusChange, EnableMouseCapture, Event, KeyCode,
+        DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
+        EnableFocusChange, EnableMouseCapture, Event, KeyCode, read,
     },
     execute, queue,
     terminal::{disable_raw_mode, enable_raw_mode},

--- a/examples/event-stream-smol.rs
+++ b/examples/event-stream-smol.rs
@@ -4,7 +4,7 @@
 
 use std::{io::stdout, time::Duration};
 
-use futures::{future::FutureExt, select, StreamExt};
+use futures::{StreamExt, future::FutureExt, select};
 use futures_timer::Delay;
 
 use crossterm::{

--- a/examples/event-stream-tokio.rs
+++ b/examples/event-stream-tokio.rs
@@ -4,7 +4,7 @@
 
 use std::{io::stdout, time::Duration};
 
-use futures::{future::FutureExt, select, StreamExt};
+use futures::{StreamExt, future::FutureExt, select};
 use futures_timer::Delay;
 
 use crossterm::{

--- a/examples/is_tty.rs
+++ b/examples/is_tty.rs
@@ -1,6 +1,6 @@
 use crossterm::{
     execute,
-    terminal::{size, SetSize},
+    terminal::{SetSize, size},
     tty::IsTty,
 };
 use std::io::{stdin, stdout};

--- a/examples/key-display.rs
+++ b/examples/key-display.rs
@@ -9,7 +9,7 @@ use std::io;
 
 use crossterm::event::KeyModifiers;
 use crossterm::{
-    event::{read, KeyCode},
+    event::{KeyCode, read},
     terminal::{disable_raw_mode, enable_raw_mode},
 };
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -5,12 +5,12 @@
 //! ## Implemented operations:
 //!
 //! - Copy: [`CopyToClipboard`](struct.CopyToClipboard.html)
-use base64::prelude::{Engine, BASE64_STANDARD};
+use base64::prelude::{BASE64_STANDARD, Engine};
 
 use std::fmt;
 use std::str::FromStr;
 
-use crate::{osc, Command};
+use crate::{Command, osc};
 
 /// Different clipboard types
 ///

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -44,7 +44,7 @@
 
 use std::fmt;
 
-use crate::{csi, impl_display, Command};
+use crate::{Command, csi, impl_display};
 
 pub(crate) mod sys;
 
@@ -432,7 +432,7 @@ mod tests {
     use crate::execute;
 
     use super::{
-        sys::position, MoveDown, MoveLeft, MoveRight, MoveTo, MoveUp, RestorePosition, SavePosition,
+        MoveDown, MoveLeft, MoveRight, MoveTo, MoveUp, RestorePosition, SavePosition, sys::position,
     };
 
     // Test is disabled, because it's failing on Travis

--- a/src/cursor/sys/windows.rs
+++ b/src/cursor/sys/windows.rs
@@ -4,10 +4,10 @@ use std::convert::TryFrom;
 use std::io;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crossterm_winapi::{result, Coord, Handle, HandleType, ScreenBuffer};
+use crossterm_winapi::{Coord, Handle, HandleType, ScreenBuffer, result};
 use winapi::{
     shared::minwindef::{FALSE, TRUE},
-    um::wincon::{SetConsoleCursorInfo, SetConsoleCursorPosition, CONSOLE_CURSOR_INFO, COORD},
+    um::wincon::{CONSOLE_CURSOR_INFO, COORD, SetConsoleCursorInfo, SetConsoleCursorPosition},
 };
 
 /// The position of the cursor, written when you save the cursor's position.

--- a/src/event.rs
+++ b/src/event.rs
@@ -133,9 +133,8 @@ use derive_more::derive::IsVariant;
 pub use stream::EventStream;
 
 use crate::{
-    csi,
+    Command, csi,
     event::{filter::EventFilter, internal::InternalEvent},
-    Command,
 };
 use std::fmt::{self, Display};
 use std::time::Duration;

--- a/src/event/internal.rs
+++ b/src/event/internal.rs
@@ -4,7 +4,7 @@ use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
 
 #[cfg(unix)]
 use crate::event::KeyboardEnhancementFlags;
-use crate::event::{filter::Filter, read::InternalEventReader, timeout::PollTimeout, Event};
+use crate::event::{Event, filter::Filter, read::InternalEventReader, timeout::PollTimeout};
 
 /// Static instance of `InternalEventReader`.
 /// This needs to be static because there can be one event reader.
@@ -32,11 +32,11 @@ where
 {
     let (mut reader, timeout) = if let Some(timeout) = timeout {
         let poll_timeout = PollTimeout::new(Some(timeout));
-        if let Some(reader) = try_lock_event_reader_for(timeout) {
-            (reader, poll_timeout.leftover())
-        } else {
-            return Ok(false);
-        }
+        let reader = match try_lock_event_reader_for(timeout) {
+            Some(reader) => reader,
+            None => return Ok(false),
+        };
+        (reader, poll_timeout.leftover())
     } else {
         (lock_event_reader(), None)
     };

--- a/src/event/read.rs
+++ b/src/event/read.rs
@@ -167,12 +167,16 @@ mod tests {
         };
 
         assert!(reader.poll(None, &InternalEventFilter).is_err());
-        assert!(reader
-            .poll(Some(Duration::from_secs(0)), &InternalEventFilter)
-            .is_err());
-        assert!(reader
-            .poll(Some(Duration::from_secs(10)), &InternalEventFilter)
-            .is_err());
+        assert!(
+            reader
+                .poll(Some(Duration::from_secs(0)), &InternalEventFilter)
+                .is_err()
+        );
+        assert!(
+            reader
+                .poll(Some(Duration::from_secs(10)), &InternalEventFilter)
+                .is_err()
+        );
     }
 
     #[test]
@@ -277,9 +281,11 @@ mod tests {
             skipped_events: Vec::with_capacity(32),
         };
 
-        assert!(!reader
-            .poll(Some(Duration::from_secs(0)), &InternalEventFilter)
-            .unwrap());
+        assert!(
+            !reader
+                .poll(Some(Duration::from_secs(0)), &InternalEventFilter)
+                .unwrap()
+        );
     }
 
     #[test]
@@ -293,9 +299,11 @@ mod tests {
         };
 
         assert!(reader.poll(None, &InternalEventFilter).unwrap());
-        assert!(reader
-            .poll(Some(Duration::from_secs(0)), &InternalEventFilter)
-            .unwrap());
+        assert!(
+            reader
+                .poll(Some(Duration::from_secs(0)), &InternalEventFilter)
+                .unwrap()
+        );
     }
 
     #[test]
@@ -345,9 +353,11 @@ mod tests {
         assert_eq!(reader.read(&InternalEventFilter).unwrap(), EVENT);
         assert_eq!(reader.read(&InternalEventFilter).unwrap(), EVENT);
         assert_eq!(reader.read(&InternalEventFilter).unwrap(), EVENT);
-        assert!(!reader
-            .poll(Some(Duration::from_secs(0)), &InternalEventFilter)
-            .unwrap());
+        assert!(
+            !reader
+                .poll(Some(Duration::from_secs(0)), &InternalEventFilter)
+                .unwrap()
+        );
     }
 
     #[test]
@@ -398,9 +408,11 @@ mod tests {
 
         assert_eq!(reader.read(&InternalEventFilter).unwrap(), EVENT);
         assert!(reader.read(&InternalEventFilter).is_err());
-        assert!(reader
-            .poll(Some(Duration::from_secs(0)), &InternalEventFilter)
-            .unwrap());
+        assert!(
+            reader
+                .poll(Some(Duration::from_secs(0)), &InternalEventFilter)
+                .unwrap()
+        );
     }
 
     #[test]

--- a/src/event/source/unix/mio.rs
+++ b/src/event/source/unix/mio.rs
@@ -1,15 +1,15 @@
 use std::{collections::VecDeque, io, time::Duration};
 
-use mio::{unix::SourceFd, Events, Interest, Poll, Token};
+use mio::{Events, Interest, Poll, Token, unix::SourceFd};
 use signal_hook_mio::v1_0::Signals;
 
 #[cfg(feature = "event-stream")]
 use crate::event::sys::Waker;
 use crate::event::{
-    internal::InternalEvent, source::EventSource, sys::unix::parse::parse_event,
-    timeout::PollTimeout, Event,
+    Event, internal::InternalEvent, source::EventSource, sys::unix::parse::parse_event,
+    timeout::PollTimeout,
 };
-use crate::terminal::sys::file_descriptor::{tty_fd, FileDesc};
+use crate::terminal::sys::file_descriptor::{FileDesc, tty_fd};
 
 // Tokens to identify file descriptor
 const TTY_TOKEN: Token = Token(0);

--- a/src/event/source/unix/tty.rs
+++ b/src/event/source/unix/tty.rs
@@ -7,14 +7,14 @@ use rustix::fd::{AsFd, AsRawFd};
 
 use signal_hook::low_level::pipe;
 
-use crate::event::timeout::PollTimeout;
 use crate::event::Event;
-use filedescriptor::{poll, pollfd, POLLIN};
+use crate::event::timeout::PollTimeout;
+use filedescriptor::{POLLIN, poll, pollfd};
 
 #[cfg(feature = "event-stream")]
 use crate::event::sys::Waker;
 use crate::event::{internal::InternalEvent, source::EventSource, sys::unix::parse::parse_event};
-use crate::terminal::sys::file_descriptor::{tty_fd, FileDesc};
+use crate::terminal::sys::file_descriptor::{FileDesc, tty_fd};
 
 /// Holds a prototypical Waker and a receiver we can wait on when doing select().
 #[cfg(feature = "event-stream")]
@@ -139,7 +139,7 @@ impl EventSource for UnixInternalEventSource {
                 Err(e) => {
                     return Err(std::io::Error::other(format!(
                         "got unexpected error while polling: {e:?}"
-                    )))
+                    )));
                 }
                 Ok(_) => (),
             };

--- a/src/event/source/windows.rs
+++ b/src/event/source/windows.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 use crossterm_winapi::{Console, Handle, InputRecord};
 
 use crate::event::{
-    sys::windows::{parse::MouseButtonsPressed, poll::WinApiPoll},
     Event,
+    sys::windows::{parse::MouseButtonsPressed, poll::WinApiPoll},
 };
 
 #[cfg(feature = "event-stream")]

--- a/src/event/stream.rs
+++ b/src/event/stream.rs
@@ -2,9 +2,9 @@ use std::{
     io,
     pin::Pin,
     sync::{
+        Arc,
         atomic::{AtomicBool, Ordering},
         mpsc::{self, SyncSender},
-        Arc,
     },
     task::{Context, Poll},
     thread,
@@ -14,10 +14,10 @@ use std::{
 use futures_core::stream::Stream;
 
 use crate::event::{
+    Event,
     filter::EventFilter,
     internal::{self, InternalEvent},
     sys::Waker,
-    Event,
 };
 
 /// A stream of `Result<Event>`.
@@ -104,7 +104,7 @@ impl Stream for EventStream {
     type Item = io::Result<Event>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let result = match internal::poll(Some(Duration::from_secs(0)), &EventFilter) {
+        match internal::poll(Some(Duration::from_secs(0)), &EventFilter) {
             Ok(true) => match internal::read(&EventFilter) {
                 Ok(InternalEvent::Event(event)) => Poll::Ready(Some(Ok(event))),
                 Err(e) => Poll::Ready(Some(Err(e))),
@@ -134,8 +134,7 @@ impl Stream for EventStream {
                 Poll::Pending
             }
             Err(e) => Poll::Ready(Some(Err(e))),
-        };
-        result
+        }
     }
 }
 

--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -347,7 +347,6 @@ fn parse_key_event_kind(kind: u8) -> KeyEventKind {
 
 pub(crate) fn parse_csi_modifier_key_code(buffer: &[u8]) -> io::Result<Option<InternalEvent>> {
     assert!(buffer.starts_with(b"\x1B[")); // ESC [
-                                           //
     let s = std::str::from_utf8(&buffer[2..buffer.len() - 1])
         .map_err(|_| could_not_parse_event_error())?;
     let mut split = s.split(';');

--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -109,21 +109,13 @@ fn try_ensure_char_case(ch: char, desired_case: CharCase) -> char {
             let mut iter = ch.to_lowercase();
             // Unwrap is safe; iterator yields one or more chars.
             let ch_lower = iter.next().unwrap();
-            if iter.next().is_none() {
-                ch_lower
-            } else {
-                ch
-            }
+            if iter.next().is_none() { ch_lower } else { ch }
         }
         CharCase::UpperCase if ch.is_lowercase() => {
             let mut iter = ch.to_uppercase();
             // Unwrap is safe; iterator yields one or more chars.
             let ch_upper = iter.next().unwrap();
-            if iter.next().is_none() {
-                ch_upper
-            } else {
-                ch
-            }
+            if iter.next().is_none() { ch_upper } else { ch }
         }
         _ => ch,
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,4 +263,6 @@ mod command;
 pub(crate) mod macros;
 
 #[cfg(all(windows, not(feature = "windows")))]
-compile_error!("Compiling on Windows with \"windows\" feature disabled. Feature \"windows\" should only be disabled when project will never be compiled on Windows.");
+compile_error!(
+    "Compiling on Windows with \"windows\" feature disabled. Feature \"windows\" should only be disabled when project will never be compiled on Windows."
+);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -224,6 +224,14 @@ mod tests {
         }
 
         #[test]
+        fn test_queue_const_block_command() {
+            let mut result = FakeWrite::default();
+            queue!(&mut result, const { FakeCommand }).unwrap();
+            assert_eq!(&result.buffer, "cmd");
+            assert!(!result.flushed);
+        }
+
+        #[test]
         fn test_execute_one() {
             let mut result = FakeWrite::default();
             execute!(&mut result, FakeCommand).unwrap();
@@ -244,6 +252,14 @@ mod tests {
             let mut result = FakeWrite::default();
             execute!(&mut result, FakeCommand, FakeCommand,).unwrap();
             assert_eq!(&result.buffer, "cmdcmd");
+            assert!(result.flushed);
+        }
+
+        #[test]
+        fn test_execute_const_block_command() {
+            let mut result = FakeWrite::default();
+            execute!(&mut result, const { FakeCommand }).unwrap();
+            assert_eq!(&result.buffer, "cmd");
             assert!(result.flushed);
         }
     }

--- a/src/style.rs
+++ b/src/style.rs
@@ -117,7 +117,7 @@ use std::{
 };
 
 use crate::command::execute_fmt;
-use crate::{csi, impl_display, Command};
+use crate::{Command, csi, impl_display};
 
 pub use self::{
     attributes::Attributes,

--- a/src/style/hyperlink.rs
+++ b/src/style/hyperlink.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{impl_display, osc, Command};
+use crate::{Command, impl_display, osc};
 
 /// A command that starts an [OSC 8 hyperlink].
 ///

--- a/src/style/stylize.rs
+++ b/src/style/stylize.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use super::{style, Attribute, Color, ContentStyle, StyledContent};
+use super::{Attribute, Color, ContentStyle, StyledContent, style};
 
 macro_rules! stylize_method {
     ($method_name:ident Attribute::$attribute:ident) => {

--- a/src/style/sys/windows.rs
+++ b/src/style/sys/windows.rs
@@ -177,7 +177,7 @@ mod tests {
     use crate::style::sys::windows::set_foreground_color;
 
     use super::{
-        Color, Colored, BG_INTENSITY, BG_RED, FG_INTENSITY, FG_RED, ORIGINAL_CONSOLE_COLOR,
+        BG_INTENSITY, BG_RED, Color, Colored, FG_INTENSITY, FG_RED, ORIGINAL_CONSOLE_COLOR,
     };
 
     #[test]

--- a/src/style/types/colored.rs
+++ b/src/style/types/colored.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::style::{parse_next_u8, Color};
+use crate::style::{Color, parse_next_u8};
 
 /// Represents a foreground or background color.
 ///
@@ -308,13 +308,15 @@ mod tests {
 
     #[test]
     fn test_no_color() {
-        std::env::set_var("NO_COLOR", "1");
-        assert!(Colored::ansi_color_disabled());
-        std::env::set_var("NO_COLOR", "XXX");
-        assert!(Colored::ansi_color_disabled());
-        std::env::set_var("NO_COLOR", "");
-        assert!(!Colored::ansi_color_disabled());
-        std::env::remove_var("NO_COLOR");
-        assert!(!Colored::ansi_color_disabled());
+        for (value, disabled) in [
+            (Some("1"), true),
+            (Some("XXX"), true),
+            (Some(""), false),
+            (None, false),
+        ] {
+            temp_env::with_var("NO_COLOR", value, || {
+                assert_eq!(Colored::ansi_color_disabled(), disabled);
+            });
+        }
     }
 }

--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -3,13 +3,13 @@
 #[cfg(feature = "events")]
 use crate::event::KeyboardEnhancementFlags;
 use crate::terminal::{
-    sys::file_descriptor::{tty_fd, FileDesc},
     WindowSize,
+    sys::file_descriptor::{FileDesc, tty_fd},
 };
 #[cfg(feature = "libc")]
 use libc::{
-    cfmakeraw, ioctl, tcgetattr, tcsetattr, termios as Termios, winsize, STDOUT_FILENO, TCSANOW,
-    TIOCGWINSZ,
+    STDOUT_FILENO, TCSANOW, TIOCGWINSZ, cfmakeraw, ioctl, tcgetattr, tcsetattr, termios as Termios,
+    winsize,
 };
 use parking_lot::Mutex;
 #[cfg(not(feature = "libc"))]
@@ -280,11 +280,7 @@ fn tput_value(arg: &str) -> Option<u16> {
         .filter_map(|b| char::from(b).to_digit(10))
         .fold(0, |v, n| v * 10 + n as u16);
 
-    if value > 0 {
-        Some(value)
-    } else {
-        None
-    }
+    if value > 0 { Some(value) } else { None }
 }
 
 /// Returns the size of the screen as determined by tput.

--- a/src/terminal/sys/windows.rs
+++ b/src/terminal/sys/windows.rs
@@ -6,7 +6,7 @@ use std::io::{self};
 use crossterm_winapi::{Console, ConsoleMode, Coord, Handle, ScreenBuffer, Size};
 use winapi::{
     shared::minwindef::DWORD,
-    um::wincon::{SetConsoleTitleW, ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT},
+    um::wincon::{ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT, SetConsoleTitleW},
 };
 
 use crate::{


### PR DESCRIPTION
## Summary

- migrate Crossterm from the Rust 2021 edition to Rust 2024
- adopt the expanded Rust 2024 expression grammar and cover top-level const-block commands in `queue!` and `execute!`
- apply the edition-specific temporary-lifetime cleanup and avoid newly unsafe environment mutation in tests
- accept the Rust 2024 Rustfmt style output and record the migration in the changelog

This is the Rust 2024 follow-up in [#1075](https://github.com/crossterm-rs/crossterm/issues/1075).

## Why now

Rust 1.85 is the first release that supports Rust 2024. [#1059](https://github.com/crossterm-rs/crossterm/pull/1059) has already set Crossterm’s MSRV to Rust 1.85, so adopting the edition does not require another compiler-version increase.

The migration follows Cargo’s [documented two-step process](https://doc.rust-lang.org/stable/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html): run `cargo fix --edition` while the manifest still declares Rust 2021, review the generated changes, and only then set `edition = "2024"`.

## Migration notes

- `cargo fix --edition` initially changed every `expr` matcher to `expr_2021`. The [Rust 2024 migration guide](https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html) describes that as a conservative compatibility fix and says most macros should keep `expr` after review. None of Crossterm’s affected macros has a competing `const` or `_` rule that the broader matcher could shadow, so they use the Rust 2024 `expr` grammar. This additionally lets `queue!` and `execute!` accept top-level `const { ... }` command expressions, which now have focused tests.
- The generated temporary-lifetime rewrite in `event::internal::poll` is expressed as an explicit `match`, keeping the lock acquisition and timeout behavior easy to audit.
- Rust 2024 makes process-environment mutation unsafe. The `NO_COLOR` test now uses the existing `temp-env` helper, which serializes the mutation and restores the previous value.
- Rustfmt’s 2024 style edition accounts for most of the 30-file diff: import ordering, expression layout, and similar mechanical formatting.
- Rust 2024 [implies Cargo resolver version 3](https://doc.rust-lang.org/stable/edition-guide/rust-2024/cargo-resolver.html). The tracked `Cargo.lock` and resolved dependency versions are unchanged.

No existing public Rust API behavior is intended to change. The public command macros gain the semver-compatible ability to accept top-level `const { ... }` expressions.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps`
- `cargo test --locked --doc --all-features` — 54 passed
- `cargo test --locked --all-targets --all-features -- --test-threads 1` — 119 passed, 7 ignored
- Rust 1.85.0 library checks with no default features and all features
- Unix library checks with no defaults, `events`, and `events,event-stream,use-dev-tty,bracketed-paste`
- `cargo package --locked --allow-dirty`
- `cargo semver-checks check-release --baseline-version 0.29.0 --all-features` — no semver update required

Windows and Linux execution are left to the existing GitHub Actions matrix.
