### PR TITLE
Establish the required CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,24 +9,157 @@ on:
       - master
   workflow_dispatch:
 
-# Keep validation read-only. Publishing will use a separate workflow with narrowly scoped permissions.
+# Keep pull request validation read-only. Publishing belongs in a separate workflow.
 # https://docs.github.com/en/actions/tutorials/authenticate-with-github_token
 permissions:
   contents: read
 
+# Actions use full commit SHAs. The rust-toolchain pin comes from master history because the action
+# requires a durable master commit when the `toolchain` input is supplied explicitly.
+# https://github.com/dtolnay/rust-toolchain#choice-of-full-length-commit-sha
+
 # A pull request keeps the same number as commits are added, so newer commits cancel stale runs.
-# Push and manual runs fall back to the ref. The workflow name prevents cross-workflow cancellation.
+# Push and manual runs fall back to the ref.
 # https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  format:
+    name: format
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: stable
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: stable
+          components: clippy
+
+      - name: Run Clippy
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
+
+  # Beta is close enough to the next stable release to give useful warning about incoming lints
+  # without the additional churn of nightly. This job is advisory: beta can change independently
+  # of the repository, so it is deliberately omitted from ci-success and allowed to fail.
+  # https://doc.rust-lang.org/clippy/continuous_integration/index.html
+  clippy-beta:
+    name: clippy (beta, advisory)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install beta Rust
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: beta
+          components: clippy
+
+      - name: Check upcoming Clippy lints
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
+
+      - name: Explain an advisory failure
+        if: ${{ failure() }}
+        run: |
+          echo "::warning::Beta Clippy found a possible future stable failure. \
+          This advisory job does not block pull requests."
+
+  docs:
+    name: docs
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: stable
+
+      - name: Check documentation
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --locked --all-features --no-deps
+
+  test:
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-2022, macos-15]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: stable
+
+      # Crossterm tests manipulate process-global terminal and environment state.
+      - name: Run tests
+        run: cargo test --locked --all-targets --all-features -- --test-threads 1
+
+  doctest:
+    name: doctest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: stable
+
+      - name: Run documentation tests
+        run: cargo test --locked --doc --all-features
+
   # `package.rust-version` is a compatibility promise, so check the library at that exact version.
   # Development tools and examples may have newer requirements without changing the crate's MSRV.
   # https://doc.rust-lang.org/cargo/reference/rust-version.html
   msrv:
-    name: Rust 1.85 library
+    name: msrv
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -36,14 +169,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust 1.85
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
         with:
           toolchain: 1.85.0
-
-      - name: Toolchain information
-        run: |
-          rustc --version
-          cargo --version
 
       - name: Check library without default features
         run: cargo check --locked --lib --no-default-features
@@ -51,85 +179,142 @@ jobs:
       - name: Check library with all public features
         run: cargo check --locked --lib --all-features
 
-  test:
-    name: ${{ matrix.rust }} on ${{ matrix.os }}
-    # Versioned labels keep OS changes deliberate instead of following the moving `-latest` labels.
-    # https://docs.github.com/en/actions/reference/runners/github-hosted-runners
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
-    # Nightly is an early warning, not a release gate. Its failures remain visible without failing
-    # the workflow, while fail-fast false lets every OS report its result after another job fails.
-    # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idcontinue-on-error
-    # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstrategyfail-fast
-    continue-on-error: ${{ matrix.can-fail }}
+  # These are deliberate compatibility points, not an exhaustive feature powerset. cargo-hack
+  # could automate broader coverage, but would add combinations, runtime, and another pinned tool
+  # before the project has decided that exhaustive feature testing is the policy.
+  # https://github.com/taiki-e/cargo-hack#usage
+  features-unix:
+    name: feature tests (Unix, ${{ matrix.name }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2022, macos-15]
-        rust: [stable, nightly]
         include:
-          - rust: stable
-            can-fail: false
-          - rust: nightly
-            can-fail: true
+          - name: defaults
+            cargo-args: ""
+          - name: serde
+            cargo-args: --features serde
+          - name: event stream
+            cargo-args: --features event-stream,events
+          - name: no defaults
+            cargo-args: --no-default-features
+          - name: events
+            cargo-args: --no-default-features --features events
+          - name: event stream and dev tty
+            cargo-args: >-
+              --no-default-features
+              --features events,event-stream,use-dev-tty,bracketed-paste
     steps:
-      # A full commit SHA is the only immutable way to select an action.
-      # https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # This workflow never pushes, so do not store its token in the checkout's Git config.
-          # https://github.com/actions/checkout/tree/v7.0.1#usage
           persist-credentials: false
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
         with:
-          toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
+          toolchain: stable
 
-      - name: Toolchain information
+      # Run rather than merely check so feature-gated test code and behavior stay covered.
+      - name: Test feature combination
+        run: cargo test --locked --lib ${{ matrix.cargo-args }} -- --test-threads 1
+
+  # Windows intentionally requires the `windows` feature. A bare no-default-features build is
+  # rejected by a compile_error in the crate root, so only supported Windows combinations pass CI.
+  features-windows:
+    name: feature tests (Windows, ${{ matrix.name }})
+    runs-on: windows-2022
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: windows
+            cargo-args: --no-default-features --features windows
+          - name: windows and events
+            cargo-args: --no-default-features --features windows,events
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: stable
+
+      # Run rather than merely check so feature-gated test code and behavior stay covered.
+      - name: Test feature combination
+        run: cargo test --locked --lib ${{ matrix.cargo-args }} -- --test-threads 1
+
+  package:
+    name: package (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-2022]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: stable
+
+      - name: Verify package
+        run: cargo package --locked
+
+  # Always run the aggregate so a failed dependency produces one failed, stable branch-protection
+  # check instead of skipping the aggregate job.
+  # https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/troubleshooting-required-status-checks
+  ci-success:
+    name: ci-success
+    if: ${{ always() }}
+    needs:
+      - format
+      - clippy
+      - docs
+      - test
+      - doctest
+      - msrv
+      - features-unix
+      - features-windows
+      - package
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every CI job to pass
+        env:
+          FORMAT_RESULT: ${{ needs.format.result }}
+          CLIPPY_RESULT: ${{ needs.clippy.result }}
+          DOCS_RESULT: ${{ needs.docs.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          DOCTEST_RESULT: ${{ needs.doctest.result }}
+          MSRV_RESULT: ${{ needs.msrv.result }}
+          FEATURES_UNIX_RESULT: ${{ needs.features-unix.result }}
+          FEATURES_WINDOWS_RESULT: ${{ needs.features-windows.result }}
+          PACKAGE_RESULT: ${{ needs.package.result }}
         run: |
-          rustc --version
-          rustfmt --version
-          rustup --version
-          cargo --version
-
-      - name: Check formatting
-        if: matrix.rust == 'stable'
-        run: cargo fmt --all -- --check
-
-      - name: Clippy
-        run: cargo clippy --all-features -- -D clippy::all
-
-      - name: Test build
-        run: cargo build
-
-      # Crossterm tests manipulate process-global terminal and environment state, so run serially.
-      - name: Test default features
-        run: cargo test --lib -- --nocapture --test-threads 1
-
-      - name: Test serde feature
-        run: cargo test --lib --features serde -- --nocapture --test-threads 1
-
-      - name: Test event-stream feature
-        run: cargo test --lib --features "event-stream,events" -- --nocapture --test-threads 1
-
-      - name: Test all features
-        run: cargo test --all-features -- --nocapture --test-threads 1
-
-      - name: Test no default features
-        if: matrix.os != 'windows-2022'
-        run: cargo test --no-default-features -- --nocapture --test-threads 1
-
-      - name: Test no default features with use-dev-tty feature enabled
-        if: matrix.os != 'windows-2022'
-        run: cargo test --no-default-features --features "use-dev-tty events event-stream bracketed-paste" -- --nocapture --test-threads 1
-
-      - name: Test no default features with windows feature enabled
-        if: matrix.os == 'windows-2022'
-        run: cargo test --no-default-features --features "windows" -- --nocapture --test-threads 1
-
-      - name: Test packaging
-        if: matrix.rust == 'stable'
-        run: cargo package
+          for result in \
+            "$FORMAT_RESULT" \
+            "$CLIPPY_RESULT" \
+            "$DOCS_RESULT" \
+            "$TEST_RESULT" \
+            "$DOCTEST_RESULT" \
+            "$MSRV_RESULT" \
+            "$FEATURES_UNIX_RESULT" \
+            "$FEATURES_WINDOWS_RESULT" \
+            "$PACKAGE_RESULT"
+          do
+            if [ "$result" != "success" ]; then
+              echo "Required CI job finished with result: $result"
+              exit 1
+            fi
+          done

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,0 +1,41 @@
+name: Compatibility
+
+on:
+  schedule:
+    # Run away from the top of the hour, when scheduled Actions are most likely to be delayed.
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule
+    - cron: "23 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compatibility:
+    name: ${{ matrix.rust }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-2022, macos-15]
+        rust: [beta, nightly]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: ${{ matrix.rust }}
+
+      # This workflow does not run for pull requests, so compatibility failures stay visible
+      # without becoming required merge checks.
+      - name: Run compatibility tests
+        run: cargo test --locked --all-targets --all-features -- --test-threads 1

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -55,7 +55,8 @@ default value.
 The code must be warning free. It's quite hard to find an error if the build logs are polluted with warnings.
 If you decide to silent a warning with (`#[allow(...)]`), please add a comment why it's required.
 
-Always consult the [Travis CI](https://travis-ci.org/crossterm-rs/crossterm/pull_requests) build logs.
+Always consult the
+[GitHub Actions](https://github.com/crossterm-rs/crossterm/actions/workflows/ci.yml) build logs.
 
 ### Forbidden Warnings
 
@@ -63,3 +64,74 @@ Search for `#![deny(...)]` in the code:
 
 * `unused_must_use`
 * `unused_imports`
+
+## Local checks
+
+Run the required checks before opening a pull request:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --locked --all-targets --all-features -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps
+cargo test --locked --doc --all-features
+cargo test --locked --all-targets --all-features -- --test-threads 1
+cargo package --locked
+```
+
+Crossterm tests run single-threaded because some tests interact with process-wide terminal and
+environment state.
+
+The minimum supported Rust version covers the library without default features and with all public
+features:
+
+```sh
+rustup run 1.85.0 cargo check --locked --lib --no-default-features
+rustup run 1.85.0 cargo check --locked --lib --all-features
+```
+
+On Unix, test the selected feature configurations:
+
+```sh
+cargo test --locked --lib -- --test-threads 1
+cargo test --locked --lib --features serde -- --test-threads 1
+cargo test --locked --lib --features event-stream,events -- --test-threads 1
+cargo test --locked --lib --no-default-features -- --test-threads 1
+cargo test --locked --lib --no-default-features --features events -- --test-threads 1
+cargo test --locked --lib --no-default-features \
+  --features events,event-stream,use-dev-tty,bracketed-paste -- --test-threads 1
+```
+
+Windows builds require the `windows` feature. The crate intentionally rejects a bare
+`--no-default-features` Windows build:
+
+```sh
+cargo test --locked --lib --no-default-features --features windows -- --test-threads 1
+cargo test --locked --lib --no-default-features --features windows,events -- --test-threads 1
+```
+
+Pull requests run these checks on GitHub Actions. Beta and nightly test compatibility checks run
+weekly and can also be started manually. Pull requests also run the advisory beta Clippy check
+described below.
+
+## CI design
+
+Crossterm's CI follows these constraints:
+
+- Required checks use stable Rust and cover formatting, warnings, documentation, tests, the
+  supported Rust version, selected feature configurations, and the publishable package.
+- Operating-system coverage is used where platform behavior matters. Selected feature tests run on
+  a representative platform to keep pull-request feedback timely.
+- The feature configurations are deliberate compatibility points rather than an exhaustive
+  powerset. [`cargo-hack`](https://github.com/taiki-e/cargo-hack) may be useful later if broader
+  coverage justifies the extra runtime, policy, and tool maintenance.
+- Beta Clippy is advisory. It warns about lints likely to reach the next stable toolchain without
+  making pull requests fail because an upstream beta toolchain changed.
+- `ci-success` is the stable check intended for branch protection. Individual jobs remain visible
+  for diagnosis, but repository rules do not need to track every matrix job name.
+- Pull-request CI is read-only and has no release or publishing authority.
+
+Run the advisory Clippy check locally with:
+
+```sh
+rustup run beta cargo clippy --locked --all-targets --all-features -- -D warnings
+```


### PR DESCRIPTION
## Summary

- split stable validation into focused format, Clippy, documentation, test, doctest, MSRV, feature, and package jobs
- add one stable `ci-success` aggregate intended for branch protection
- restore tests for the selected default, Serde, event-stream, minimal Unix, and supported Windows feature configurations
- add an advisory beta-Clippy check so incoming stable lints can be handled before they break every pull request
- move beta and nightly test compatibility checks to a weekly and manually dispatched workflow
- document the local commands and the design constraints behind the CI policy

This is the next implementation slice from #1075. It does not add caching, secrets, release permissions, or publishing authority.

## Coverage

Stable tests run with all targets and features on Linux, macOS, and Windows. Tests remain single-threaded because Crossterm has tests that manipulate process-global terminal and environment state.

The workflow also checks:

- Rust 1.85 with no default features and all public features
- default, Serde, and event-stream unit tests on Unix
- the selected minimal Unix feature configurations
- the supported `windows` and `windows,events` configurations on Windows
- the publishable package on Linux and Windows

A bare Windows `--no-default-features` build is not included as a passing check: Crossterm deliberately rejects Windows builds without the `windows` feature in `src/lib.rs`. Testing the two supported configurations records the actual invariant without making an expected failure part of the required gate.

## CI design

Required checks use stable Rust and cover deterministic properties directly relevant to a releasable crate. Cross-platform all-feature tests catch operating-system differences, while the smaller feature matrix tests deliberate compatibility points on representative platforms to keep feedback timely.

This is not an exhaustive feature powerset. [`cargo-hack`](https://github.com/taiki-e/cargo-hack) supports `--each-feature` and `--feature-powerset`, but adopting it would mean choosing a broader feature-compatibility policy, paying the additional runtime, and maintaining another pinned tool. That is better considered with the auxiliary-tool integrity work in the next tracking-issue slice rather than introduced implicitly here.

Stable Clippy is required. Beta Clippy also runs on pull requests with `continue-on-error`: it is an early warning for lints likely to arrive in the next stable toolchain, but an upstream beta change must not block merges. The job is deliberately excluded from `ci-success`, labels itself advisory, and emits a warning explaining failures. This follows the motivation in [Clippy's CI guidance](https://doc.rust-lang.org/clippy/continuous_integration/index.html), while choosing beta over nightly to focus on the next stable release with less churn.

Beta and nightly test compatibility remain in a separate weekly and manually dispatched workflow. They are visible signals without becoming ordinary pull-request gates. The weekly schedule runs away from the top of the hour because GitHub notes that scheduled workflows may be delayed during high-load periods.

Caching is intentionally deferred until job timings show that its additional state and maintenance are worthwhile.

## Branch-protection design

`ci-success` uses `always()` so it still reports a definitive failure when one of its dependencies fails instead of becoming a skipped required check, as described in [GitHub's required-check troubleshooting documentation](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/troubleshooting-required-status-checks).

The aggregate has a unique, stable name so branch protection can require it without depending on every matrix job name. GitHub recommends unique job names when required checks may be produced by multiple workflows: [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches).

Pull-request workflows are read-only, persist no checkout credentials, and have no secrets or publishing authority.

Third-party actions are pinned to full commit SHAs. The Rust installer uses a commit from its durable `master` history because the action requires that pin shape when workflows provide the `toolchain` input explicitly.

## Validation

- `actionlint` 1.7.12
- `zizmor` 1.26.1
- formatting, strict stable and beta Clippy, Rustdoc warnings, doctests, and the all-target/all-feature test suite
- Rust 1.85 checks
- every selected Unix feature-test configuration
- package verification
