### PR TITLE
Enforce dependency and workflow policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,29 @@ updates:
     # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups
     schedule:
       interval: monthly
+    # Give new releases time to accumulate community review before adopting them automatically.
+    # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1
+
+  - package-ecosystem: cargo
+    directory: /
+    # Leave Cargo.toml unchanged when its requirements already permit the update. If they do not,
+    # widen the requirement so useful out-of-range releases are surfaced for normal review.
+    # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy
+    versioning-strategy: increase-if-necessary
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    # One grouped PR keeps routine dependency maintenance reviewable without per-crate noise.
+    groups:
+      cargo-dependencies:
         patterns:
           - "*"
     open-pull-requests-limit: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,52 @@ jobs:
       - name: Verify package
         run: cargo package --locked
 
+  # Compare the resolved dependency graph with the security, license, and source rules in
+  # deny.toml. Vulnerable or yanked packages, unapproved licenses, and unreviewed sources fail CI.
+  # Duplicate versions are not checked because Cargo may legitimately resolve more than one
+  # semver-incompatible version and Crossterm has not adopted a duplicate-version policy.
+  dependency-policy:
+    name: dependency policy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check dependency policy
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+        with:
+          arguments: --locked
+          command: check
+          command-arguments: advisories licenses sources
+
+  # Actionlint validates GitHub Actions structure and expressions; Zizmor detects workflow security
+  # problems such as excessive permissions, unpinned actions, and dangerous triggers. This required
+  # job uses only the checked-out definitions so fork pull requests receive the same blocking
+  # result without GitHub API access. SARIF can follow when Code Scanning can be configured.
+  # https://docs.zizmor.sh/usage/#operating-modes
+  workflow-integrity:
+    name: workflow integrity
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check workflow syntax
+        uses: docker://rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+
+      - name: Audit workflow security
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        with:
+          version: 1.28.0
+          online-audits: false
+          advanced-security: false
+
   # Always run the aggregate so a failed dependency produces one failed, stable branch-protection
   # check instead of skipping the aggregate job.
   # https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/troubleshooting-required-status-checks
@@ -287,6 +333,8 @@ jobs:
       - features-unix
       - features-windows
       - package
+      - dependency-policy
+      - workflow-integrity
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -301,6 +349,8 @@ jobs:
           FEATURES_UNIX_RESULT: ${{ needs.features-unix.result }}
           FEATURES_WINDOWS_RESULT: ${{ needs.features-windows.result }}
           PACKAGE_RESULT: ${{ needs.package.result }}
+          DEPENDENCY_POLICY_RESULT: ${{ needs.dependency-policy.result }}
+          WORKFLOW_INTEGRITY_RESULT: ${{ needs.workflow-integrity.result }}
         run: |
           for result in \
             "$FORMAT_RESULT" \
@@ -311,7 +361,9 @@ jobs:
             "$MSRV_RESULT" \
             "$FEATURES_UNIX_RESULT" \
             "$FEATURES_WINDOWS_RESULT" \
-            "$PACKAGE_RESULT"
+            "$PACKAGE_RESULT" \
+            "$DEPENDENCY_POLICY_RESULT" \
+            "$WORKFLOW_INTEGRITY_RESULT"
           do
             if [ "$result" != "success" ]; then
               echo "Required CI job finished with result: $result"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,31 @@
+# Check the complete public feature graph, including target-specific and development dependencies.
+# https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+[graph]
+all-features = true
+
+# Vulnerable and unsound advisories fail by default. Yanked releases are denied explicitly because
+# they may remain usable from Cargo.lock even though they are no longer selectable.
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+yanked = "deny"
+
+# Keep this list to licenses found in the reviewed dependency graph. Adding a dependency under a
+# different license therefore requires an explicit policy change.
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+include-dev = true
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "Unicode-3.0",
+]
+
+# Dependencies should come from crates.io. Any alternative registry or Git source needs separate
+# review and an explicit entry here.
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -76,10 +76,28 @@ RUSTDOCFLAGS="-D warnings" cargo doc --locked --all-features --no-deps
 cargo test --locked --doc --all-features
 cargo test --locked --all-targets --all-features -- --test-threads 1
 cargo package --locked
+cargo deny --locked check advisories licenses sources
+actionlint
+zizmor --offline --strict-collection .
 ```
 
 Crossterm tests run single-threaded because some tests interact with process-wide terminal and
 environment state.
+
+The dependency policy check uses `cargo-deny`. Its reviewed license and source policies live in
+[`deny.toml`](../deny.toml).
+
+Install the additional CI tools using their maintained instructions:
+[cargo-deny](https://embarkstudios.github.io/cargo-deny/getting-started/installation.html),
+[Actionlint](https://github.com/rhysd/actionlint/blob/main/docs/install.md), and
+[Zizmor](https://docs.zizmor.sh/installation/).
+
+[Actionlint](https://github.com/rhysd/actionlint) understands the GitHub Actions workflow schema and
+expression types, so it catches invalid workflow structure and expressions that a generic YAML
+parser cannot. [Zizmor](https://docs.zizmor.sh/audits/) looks for security problems such as
+excessive permissions, unpinned actions, persisted credentials, dangerous triggers, and template
+injection. The required Zizmor check disables online audits so it remains safe and deterministic
+for fork pull requests.
 
 The minimum supported Rust version covers the library without default features and with all public
 features:
@@ -126,6 +144,9 @@ Crossterm's CI follows these constraints:
   coverage justifies the extra runtime, policy, and tool maintenance.
 - Beta Clippy is advisory. It warns about lints likely to reach the next stable toolchain without
   making pull requests fail because an upstream beta toolchain changed.
+- Dependency policy covers the complete feature graph. Vulnerable or yanked packages, unapproved
+  licenses, and unreviewed registries or Git sources block a pull request.
+- Actionlint checks workflow structure and expressions, while Zizmor audits workflow security.
 - `ci-success` is the stable check intended for branch protection. Individual jobs remain visible
   for diagnosis, but repository rules do not need to track every matrix job name.
 - Pull-request CI is read-only and has no release or publishing authority.


### PR DESCRIPTION
## Summary

- add a blocking `cargo-deny 0.20.2` check for advisories, yanked packages, licenses, registries, and Git sources
- check the committed lockfile across all features and make the result part of `ci-success`
- add one grouped monthly Dependabot update that changes requirements only when necessary
- add blocking Actionlint and Zizmor checks for workflow syntax and security
- document the local command and the CI policy

## Why

This is the dependency-policy part of the CI plan in #1075. It gives compatible lockfile refreshes a regular path while ensuring that dependency changes cannot silently add a vulnerable or yanked release, a new license, or an unreviewed source.

The license allowlist records the graph that `cargo-deny` actually accepts today: MIT, Apache-2.0, Apache-2.0 with LLVM exception, and Unicode-3.0. The initial plan listed several licenses that the current graph does not require; keeping those out means a future dependency with a different license prompts an explicit review.

Dependabot uses `versioning-strategy: increase-if-necessary`. It leaves `Cargo.toml` unchanged when the existing requirement already permits the update, but can widen the requirement when necessary so useful out-of-range releases are surfaced rather than silently ignored. Any manifest change still receives normal review. The updates are grouped monthly to avoid one PR per crate.

Both Dependabot updaters use a seven-day cooldown. This gives newly released versions time to accumulate community review before Crossterm adopts them automatically.

The `bans` check is deliberately not enabled in this PR. Duplicate semver-incompatible versions can be legitimate, and Crossterm has not adopted a duplicate-dependency policy.

Workflow validation uses Actionlint 1.7.12 and Zizmor 1.28.0. Actionlint understands the GitHub Actions schema and expression types, catching mistakes that a generic YAML parser cannot. Zizmor audits workflow security issues such as excessive permissions, unpinned actions, persisted credentials, dangerous triggers, and template injection.

Zizmor runs without online audits or SARIF upload so the required check remains read-only and works for fork pull requests. SARIF can be enabled through the official Zizmor action after the repository's Code Scanning settings can be configured.

The workflow uses the pinned first-party cargo-deny and Zizmor actions and Actionlint's official container image. The image is pinned by digest as well as its human-readable release tag.

API compatibility reporting remains a separate follow-up because it has different policy and failure semantics.

## Validation

- `cargo deny --locked check advisories licenses sources`
- Actionlint 1.7.12
- Zizmor 1.28.0
- parsed `.github/dependabot.yml`
- checked the diff for whitespace errors
