### PR TITLE
Remove the libc backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Remove `IsTty` trait.
   Use the standard library's [`std::io::IsTerminal`](https://doc.rust-lang.org/std/io/trait.IsTerminal.html) trait instead,
   which provides equivalent functionality.
+- Remove the `libc` feature and always use rustix for Unix terminal operations.
 
 ## Changed ⚙️
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,6 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-timer",
- "libc",
  "mio",
  "parking_lot",
  "rustix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,9 +72,6 @@ winapi = { version = "0.3.9", optional = true, features = ["winuser", "winerror"
 # UNIX dependencies
 [target.'cfg(unix)'.dependencies]
 filedescriptor = { version = "0.8", optional = true }
-# Default to using rustix for UNIX systems, but provide an option to use libc for backwards
-# compatibility.
-libc = { version = "0.2", default-features = false, optional = true }
 mio = { version = "1.0", features = ["os-poll"], optional = true }
 rustix = { version = "1", default-features = false, features = ["std", "stdio", "termios"] }
 signal-hook = { version = "0.3.17", optional = true }

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ This can disable `mio` / `signal-hook` / `signal-hook-mio` dependencies.
 |:---------------|:---------------------------------------------------------------------------------|:--------------------------------------|
 | `bitflags`     | `KeyModifiers`, those are differ based on input.                                 | always                                |
 | `parking_lot`  | locking `RwLock`s with a timeout, const mutexes.                                 | always                                |
-| `libc`         | UNIX terminal_size/raw modes/set_title and several other low level functionality. | optional (`events` feature), UNIX only |
+| `rustix`       | UNIX terminal size/raw modes and other low-level functionality.                   | UNIX only                              |
 | `Mio`          | event readiness polling, waking up poller                                        | optional (`events` feature), UNIX only |
 | `signal-hook`  | signal-hook is used to handle terminal resize SIGNAL with Mio.                   |  optional (`events` feature),UNIX only |
 | `winapi`       | Used for low-level windows system calls which ANSI codes can't replace           | windows only                          |

--- a/src/event/source/unix/tty.rs
+++ b/src/event/source/unix/tty.rs
@@ -1,8 +1,5 @@
-#[cfg(feature = "libc")]
-use std::os::unix::prelude::AsRawFd;
 use std::{collections::VecDeque, io, os::unix::net::UnixStream, time::Duration};
 
-#[cfg(not(feature = "libc"))]
 use rustix::fd::{AsFd, AsRawFd};
 
 use signal_hook::low_level::pipe;
@@ -68,9 +65,6 @@ impl UnixInternalEventSource {
             winch_signal_receiver: {
                 let (receiver, sender) = nonblocking_unix_pair()?;
                 // Unregistering is unnecessary because EventSource is a singleton
-                #[cfg(feature = "libc")]
-                pipe::register(libc::SIGWINCH, sender)?;
-                #[cfg(not(feature = "libc"))]
                 pipe::register(rustix::process::Signal::WINCH.as_raw(), sender)?;
                 receiver
             },
@@ -163,9 +157,6 @@ impl EventSource for UnixInternalEventSource {
                 }
             }
             if fds[1].revents & POLLIN != 0 {
-                #[cfg(feature = "libc")]
-                let fd = FileDesc::new(self.winch_signal_receiver.as_raw_fd(), false);
-                #[cfg(not(feature = "libc"))]
                 let fd = FileDesc::Borrowed(self.winch_signal_receiver.as_fd());
                 // drain the pipe
                 while read_complete(&fd, &mut [0; 1024])? != 0 {}
@@ -183,9 +174,6 @@ impl EventSource for UnixInternalEventSource {
 
             #[cfg(feature = "event-stream")]
             if fds[2].revents & POLLIN != 0 {
-                #[cfg(feature = "libc")]
-                let fd = FileDesc::new(self.wake_pipe.receiver.as_raw_fd(), false);
-                #[cfg(not(feature = "libc"))]
                 let fd = FileDesc::Borrowed(self.wake_pipe.receiver.as_fd());
                 // drain the pipe
                 while read_complete(&fd, &mut [0; 1024])? != 0 {}

--- a/src/terminal/sys/file_descriptor.rs
+++ b/src/terminal/sys/file_descriptor.rs
@@ -1,76 +1,16 @@
 use std::io;
 
-#[cfg(feature = "libc")]
-use libc::size_t;
-#[cfg(not(feature = "libc"))]
 use rustix::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd};
-#[cfg(feature = "libc")]
-use std::{
-    fs,
-    marker::PhantomData,
-    os::unix::{
-        io::{IntoRawFd, RawFd},
-        prelude::AsRawFd,
-    },
-};
 
 /// A file descriptor wrapper.
 ///
 /// It allows to retrieve raw file descriptor, write to the file descriptor and
 /// mainly it closes the file descriptor once dropped.
-#[derive(Debug)]
-#[cfg(feature = "libc")]
-pub struct FileDesc<'a> {
-    fd: RawFd,
-    close_on_drop: bool,
-    phantom: PhantomData<&'a ()>,
-}
-
-#[cfg(not(feature = "libc"))]
 pub enum FileDesc<'a> {
     Owned(OwnedFd),
     Borrowed(BorrowedFd<'a>),
 }
 
-#[cfg(feature = "libc")]
-impl FileDesc<'_> {
-    /// Constructs a new `FileDesc` with the given `RawFd`.
-    ///
-    /// # Arguments
-    ///
-    /// * `fd` - raw file descriptor
-    /// * `close_on_drop` - specify if the raw file descriptor should be closed once the `FileDesc` is dropped
-    pub fn new(fd: RawFd, close_on_drop: bool) -> FileDesc<'static> {
-        FileDesc {
-            fd,
-            close_on_drop,
-            phantom: PhantomData,
-        }
-    }
-
-    pub fn read(&self, buffer: &mut [u8]) -> io::Result<usize> {
-        let result = unsafe {
-            libc::read(
-                self.fd,
-                buffer.as_mut_ptr() as *mut libc::c_void,
-                buffer.len() as size_t,
-            )
-        };
-
-        if result < 0 {
-            Err(io::Error::last_os_error())
-        } else {
-            Ok(result as usize)
-        }
-    }
-
-    /// Returns the underlying file descriptor.
-    pub fn raw_fd(&self) -> RawFd {
-        self.fd
-    }
-}
-
-#[cfg(not(feature = "libc"))]
 impl FileDesc<'_> {
     pub fn read(&self, buffer: &mut [u8]) -> io::Result<usize> {
         let fd = match self {
@@ -89,27 +29,12 @@ impl FileDesc<'_> {
     }
 }
 
-#[cfg(feature = "libc")]
-impl Drop for FileDesc<'_> {
-    fn drop(&mut self) {
-        if self.close_on_drop {
-            // Note that errors are ignored when closing a file descriptor. The
-            // reason for this is that if an error occurs we don't actually know if
-            // the file descriptor was closed or not, and if we retried (for
-            // something like EINTR), we might close another valid file descriptor
-            // opened after we closed ours.
-            let _ = unsafe { libc::close(self.fd) };
-        }
-    }
-}
-
 impl AsRawFd for FileDesc<'_> {
     fn as_raw_fd(&self) -> RawFd {
         self.raw_fd()
     }
 }
 
-#[cfg(not(feature = "libc"))]
 impl AsFd for FileDesc<'_> {
     fn as_fd(&self) -> BorrowedFd<'_> {
         match self {
@@ -119,26 +44,6 @@ impl AsFd for FileDesc<'_> {
     }
 }
 
-#[cfg(feature = "libc")]
-/// Creates a file descriptor pointing to the standard input or `/dev/tty`.
-pub fn tty_fd() -> io::Result<FileDesc<'static>> {
-    let (fd, close_on_drop) = if unsafe { libc::isatty(libc::STDIN_FILENO) == 1 } {
-        (libc::STDIN_FILENO, false)
-    } else {
-        (
-            fs::OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open("/dev/tty")?
-                .into_raw_fd(),
-            true,
-        )
-    };
-
-    Ok(FileDesc::new(fd, close_on_drop))
-}
-
-#[cfg(not(feature = "libc"))]
 /// Creates a file descriptor pointing to the standard input or `/dev/tty`.
 pub fn tty_fd() -> io::Result<FileDesc<'static>> {
     use std::fs::File;

--- a/src/terminal/sys/unix.rs
+++ b/src/terminal/sys/unix.rs
@@ -6,24 +6,13 @@ use crate::terminal::{
     WindowSize,
     sys::file_descriptor::{FileDesc, tty_fd},
 };
-#[cfg(feature = "libc")]
-use libc::{
-    STDOUT_FILENO, TCSANOW, TIOCGWINSZ, cfmakeraw, ioctl, tcgetattr, tcsetattr, termios as Termios,
-    winsize,
-};
 use parking_lot::Mutex;
-#[cfg(not(feature = "libc"))]
 use rustix::{
     fd::AsFd,
     termios::{Termios, Winsize},
 };
 
 use std::{fs::File, io, process};
-#[cfg(feature = "libc")]
-use std::{
-    mem,
-    os::unix::io::{IntoRawFd, RawFd},
-};
 
 // Some(Termios) -> we're in the raw mode and this is the previous mode
 // None -> we're not in the raw mode
@@ -33,18 +22,6 @@ pub(crate) fn is_raw_mode_enabled() -> bool {
     TERMINAL_MODE_PRIOR_RAW_MODE.lock().is_some()
 }
 
-#[cfg(feature = "libc")]
-impl From<winsize> for WindowSize {
-    fn from(size: winsize) -> WindowSize {
-        WindowSize {
-            columns: size.ws_col,
-            rows: size.ws_row,
-            width: size.ws_xpixel,
-            height: size.ws_ypixel,
-        }
-    }
-}
-#[cfg(not(feature = "libc"))]
 impl From<Winsize> for WindowSize {
     fn from(size: Winsize) -> WindowSize {
         WindowSize {
@@ -56,39 +33,12 @@ impl From<Winsize> for WindowSize {
     }
 }
 
-#[allow(clippy::useless_conversion)]
-#[cfg(feature = "libc")]
-pub(crate) fn window_size() -> io::Result<WindowSize> {
-    // http://rosettacode.org/wiki/Terminal_control/Dimensions#Library:_BSD_libc
-    let mut size = winsize {
-        ws_row: 0,
-        ws_col: 0,
-        ws_xpixel: 0,
-        ws_ypixel: 0,
-    };
-
-    let file = File::open("/dev/tty").map(|file| FileDesc::new(file.into_raw_fd(), true));
-    let fd = if let Ok(file) = &file {
-        file.raw_fd()
-    } else {
-        // Fallback to libc::STDOUT_FILENO if /dev/tty is missing
-        STDOUT_FILENO
-    };
-
-    if wrap_with_result(unsafe { ioctl(fd, TIOCGWINSZ.into(), &mut size) }).is_ok() {
-        return Ok(size.into());
-    }
-
-    Err(std::io::Error::last_os_error().into())
-}
-
-#[cfg(not(feature = "libc"))]
 pub(crate) fn window_size() -> io::Result<WindowSize> {
     let file = File::open("/dev/tty").map(|file| FileDesc::Owned(file.into()));
     let fd = if let Ok(file) = &file {
         file.as_fd()
     } else {
-        // Fallback to libc::STDOUT_FILENO if /dev/tty is missing
+        // Fall back to standard output if /dev/tty is missing.
         rustix::stdio::stdout()
     };
     let size = rustix::termios::tcgetwinsize(fd)?;
@@ -104,25 +54,6 @@ pub(crate) fn size() -> io::Result<(u16, u16)> {
     tput_size().ok_or_else(|| std::io::Error::last_os_error().into())
 }
 
-#[cfg(feature = "libc")]
-pub(crate) fn enable_raw_mode() -> io::Result<()> {
-    let mut original_mode = TERMINAL_MODE_PRIOR_RAW_MODE.lock();
-    if original_mode.is_some() {
-        return Ok(());
-    }
-
-    let tty = tty_fd()?;
-    let fd = tty.raw_fd();
-    let mut ios = get_terminal_attr(fd)?;
-    let original_mode_ios = ios;
-    raw_terminal_attr(&mut ios);
-    set_terminal_attr(fd, &ios)?;
-    // Keep it last - set the original mode only if we were able to switch to the raw mode
-    *original_mode = Some(original_mode_ios);
-    Ok(())
-}
-
-#[cfg(not(feature = "libc"))]
 pub(crate) fn enable_raw_mode() -> io::Result<()> {
     let mut original_mode = TERMINAL_MODE_PRIOR_RAW_MODE.lock();
     if original_mode.is_some() {
@@ -144,19 +75,6 @@ pub(crate) fn enable_raw_mode() -> io::Result<()> {
 /// More precisely, reset the whole termios mode to what it was before the first call
 /// to [enable_raw_mode]. If you don't mess with termios outside of crossterm, it's
 /// effectively disabling the raw mode and doing nothing else.
-#[cfg(feature = "libc")]
-pub(crate) fn disable_raw_mode() -> io::Result<()> {
-    let mut original_mode = TERMINAL_MODE_PRIOR_RAW_MODE.lock();
-    if let Some(original_mode_ios) = original_mode.as_ref() {
-        let tty = tty_fd()?;
-        set_terminal_attr(tty.raw_fd(), original_mode_ios)?;
-        // Keep it last - remove the original mode only if we were able to switch back
-        *original_mode = None;
-    }
-    Ok(())
-}
-
-#[cfg(not(feature = "libc"))]
 pub(crate) fn disable_raw_mode() -> io::Result<()> {
     let mut original_mode = TERMINAL_MODE_PRIOR_RAW_MODE.lock();
     if let Some(original_mode_ios) = original_mode.as_ref() {
@@ -168,13 +86,11 @@ pub(crate) fn disable_raw_mode() -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(not(feature = "libc"))]
 fn get_terminal_attr(fd: impl AsFd) -> io::Result<Termios> {
     let result = rustix::termios::tcgetattr(fd)?;
     Ok(result)
 }
 
-#[cfg(not(feature = "libc"))]
 fn set_terminal_attr(fd: impl AsFd, termios: &Termios) -> io::Result<()> {
     rustix::termios::tcsetattr(fd, rustix::termios::OptionalActions::Now, termios)?;
     Ok(())
@@ -291,34 +207,5 @@ fn tput_size() -> Option<(u16, u16)> {
     match (tput_value("cols"), tput_value("lines")) {
         (Some(w), Some(h)) => Some((w, h)),
         _ => None,
-    }
-}
-
-#[cfg(feature = "libc")]
-// Transform the given mode into an raw mode (non-canonical) mode.
-fn raw_terminal_attr(termios: &mut Termios) {
-    unsafe { cfmakeraw(termios) }
-}
-
-#[cfg(feature = "libc")]
-fn get_terminal_attr(fd: RawFd) -> io::Result<Termios> {
-    unsafe {
-        let mut termios = mem::zeroed();
-        wrap_with_result(tcgetattr(fd, &mut termios))?;
-        Ok(termios)
-    }
-}
-
-#[cfg(feature = "libc")]
-fn set_terminal_attr(fd: RawFd, termios: &Termios) -> io::Result<()> {
-    wrap_with_result(unsafe { tcsetattr(fd, TCSANOW, termios) })
-}
-
-#[cfg(feature = "libc")]
-fn wrap_with_result(result: i32) -> io::Result<()> {
-    if result == -1 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- Remove the optional `libc` dependency and its implicit Cargo feature.
- Use rustix as the only Unix terminal backend.
- Remove the duplicate file-descriptor, terminal-mode, window-size, and signal paths.
- Update the changelog and dependency documentation.

## Compatibility and deprecation context

Rustix became the default backend in [#892](https://github.com/crossterm-rs/crossterm/pull/892), closing [#847](https://github.com/crossterm-rs/crossterm/issues/847). The libc implementation was deliberately retained as a temporary compatibility escape hatch while the new backend gained real-world coverage. The original discussion explicitly proposed removing that escape hatch in the following breaking release if the migration went well ([#878 comment](https://github.com/crossterm-rs/crossterm/pull/878#issuecomment-2111901696)).

The Cargo feature was not formally annotated as deprecated, but it has served that temporary fallback role since rustix became the default. This PR completes that migration in the next breaking release.

The known rustix-specific Crossterm regressions have been resolved:

- WSL and Android rejected `TCGETS2`; rustix added a legacy `TCGETS` fallback and Crossterm adopted the fixed release in [#926](https://github.com/crossterm-rs/crossterm/pull/926), resolving [#912](https://github.com/crossterm-rs/crossterm/issues/912).
- The `use-dev-tty` feature initially omitted rustix's `process` feature; [#906](https://github.com/crossterm-rs/crossterm/pull/906) resolved [#905](https://github.com/crossterm-rs/crossterm/issues/905).
- The `use-dev-tty + event-stream` combination initially failed to compile, with libc serving as a workaround; [#955](https://github.com/crossterm-rs/crossterm/pull/955) resolved [#935](https://github.com/crossterm-rs/crossterm/issues/935) and added that combination to CI.

The only meaningful library found forwarding `crossterm/libc` is Reedline. It added the feature in [reedline#1014](https://github.com/nushell/reedline/pull/1014) for emulators that did not implement `TCGETS2`/`TCSETS2` or returned a nonstandard error instead of allowing rustix's fallback. That motivating compatibility gap has since closed:

- Rustix has fallen back from `TCGETS2`/`TCSETS2` to the legacy ioctls for standard unsupported-call errors since [rustix#1147](https://github.com/bytecodealliance/rustix/pull/1147).
- CheerpX 1.2.7 implemented the missing calls, resolving [WebVM #214](https://github.com/leaningtech/webvm/issues/214#issuecomment-3907814619).
- QEMU implemented termios2 support in [qemu@e9a8a10](https://github.com/qemu/qemu/commit/e9a8a10e84c1bf6e2e8be000e4dd5c83ba0d8470), and the corresponding [Ubuntu QEMU bug](https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2133804) is Fix Released, including Jammy and Noble.

The residual compatibility change is intentional: obsolete emulator builds that neither implement the newer ioctls nor return a fallback-compatible error can no longer select Crossterm's libc backend. Downstreams forwarding or enabling `crossterm/libc` must remove that feature when updating to the next breaking Crossterm release. Existing Crossterm 0.29 dependency resolutions are unaffected.

This removes Crossterm's direct libc backend; it does not promise that the `libc` crate disappears transitively from every dependency graph.

## Edge-case audit

I reviewed every Crossterm issue and pull request mentioning libc or rustix. The remaining open Unix terminal issues concern TTY selection, redirected standard streams, macOS `/dev/tty` polling, and competing readers—not differences between the libc and rustix wrappers. In particular, [#396](https://github.com/crossterm-rs/crossterm/issues/396), [#692](https://github.com/crossterm-rs/crossterm/issues/692), [#828](https://github.com/crossterm-rs/crossterm/issues/828), [#996](https://github.com/crossterm-rs/crossterm/issues/996), and [#957](https://github.com/crossterm-rs/crossterm/pull/957) do not require retaining the duplicate backend.

Open pull requests that currently contain parallel libc/rustix paths will need to rebase and retain only their rustix implementation, but they do not expose an unresolved compatibility blocker.

## Validation

- Formatting, Clippy with all targets/features, docs, and doctests
- Full tests with all targets/features
- Rust 1.85 checks with default and all features
- Supported Unix feature combinations, including `events + event-stream + use-dev-tty`
- Package verification and dependency policy
- Workflow validation with actionlint and zizmor

The required GitHub matrix will additionally run the suite on Linux, Windows, and macOS.
