### PR TITLE
cargo: fix for direct-minimal-versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,41 @@ jobs:
       - name: Check library with all public features
         run: cargo check --locked --lib --all-features
 
+  # Check that each direct dependency's declared lower bound can build the published library.
+  # cargo-minimal-versions uses nightly Cargo for dependency resolution, then stable Cargo for the
+  # check itself. Exclude examples and development dependencies, matching the library-only MSRV
+  # policy above.
+  # https://github.com/taiki-e/cargo-minimal-versions
+  minimal-versions:
+    name: minimal versions
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install nightly Rust for dependency resolution
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: nightly
+
+      # Install stable last so cargo-minimal-versions checks the dependency floor with stable Rust.
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
+        with:
+          toolchain: stable
+
+      - name: Install minimal versions tools
+        uses: taiki-e/install-action@a6b2e2dcd845ddd7f509ce4f3ed3d922b80cc5d9 # v2.84.0
+        with:
+          tool: cargo-minimal-versions,cargo-hack
+          fallback: none
+
+      - name: Check direct dependency lower bounds
+        run: cargo minimal-versions check --direct --lib --all-features
+
   # These are deliberate compatibility points, not an exhaustive feature powerset. cargo-hack
   # could automate broader coverage, but would add combinations, runtime, and another pinned tool
   # before the project has decided that exhaustive feature testing is the policy.
@@ -330,6 +365,7 @@ jobs:
       - test
       - doctest
       - msrv
+      - minimal-versions
       - features-unix
       - features-windows
       - package
@@ -346,6 +382,7 @@ jobs:
           TEST_RESULT: ${{ needs.test.result }}
           DOCTEST_RESULT: ${{ needs.doctest.result }}
           MSRV_RESULT: ${{ needs.msrv.result }}
+          MINIMAL_VERSIONS_RESULT: ${{ needs.minimal-versions.result }}
           FEATURES_UNIX_RESULT: ${{ needs.features-unix.result }}
           FEATURES_WINDOWS_RESULT: ${{ needs.features-windows.result }}
           PACKAGE_RESULT: ${{ needs.package.result }}
@@ -359,6 +396,7 @@ jobs:
             "$TEST_RESULT" \
             "$DOCTEST_RESULT" \
             "$MSRV_RESULT" \
+            "$MINIMAL_VERSIONS_RESULT" \
             "$FEATURES_UNIX_RESULT" \
             "$FEATURES_WINDOWS_RESULT" \
             "$PACKAGE_RESULT" \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,9 +60,9 @@ base64 = { version = "0.22", optional = true }
 bitflags = { version = "2.9" }
 derive_more = { version = "2.0.0", features = ["is_variant"], optional = true }
 document-features = { version = "0.2.11", optional = true }
-futures-core = { version = "0.3", optional = true, default-features = false }
-parking_lot = "0.12"
-serde = { version = "1.0", features = ["derive"], optional = true }
+futures-core = { version = "0.3.31", optional = true, default-features = false }
+parking_lot = "0.12.1"
+serde = { version = "1.0.103", features = ["derive"], optional = true }
 
 # Windows dependencies
 [target.'cfg(windows)'.dependencies]
@@ -74,8 +74,8 @@ winapi = { version = "0.3.9", optional = true, features = ["winuser", "winerror"
 filedescriptor = { version = "0.8", optional = true }
 # Default to using rustix for UNIX systems, but provide an option to use libc for backwards
 # compatibility.
-libc = { version = "0.2", default-features = false, optional = true }
-mio = { version = "1.0", features = ["os-poll"], optional = true }
+libc = { version = "0.2.168", default-features = false, optional = true }
+mio = { version = "1.0.1", features = ["os-poll"], optional = true }
 rustix = { version = "1", default-features = false, features = ["std", "stdio", "termios"] }
 signal-hook = { version = "0.3.17", optional = true }
 signal-hook-mio = { version = "0.2.4", features = ["support-v1_0"], optional = true }


### PR DESCRIPTION
Ensure we can build with `cargo +nightly update -Z direct-minimal-versions`

This will need a CI workflow.