### PR TITLE
add the `README.md` referenced by `examples/interactive-demo/Cargo.toml`

### DIFF
--- a/examples/interactive-demo/README.md
+++ b/examples/interactive-demo/README.md
@@ -1,0 +1,34 @@
+# Crossterm Interactive Demo
+
+An interactive terminal application for demonstrating and manually testing Crossterm functionality.
+
+The demo includes tests for:
+
+* cursor movement and visibility;
+* foreground and background colors;
+* text attributes;
+* terminal input events;
+* synchronized output.
+
+## Running the demo
+
+From the root of the Crossterm repository, run:
+
+```sh
+cargo run --manifest-path examples/interactive-demo/Cargo.toml
+```
+
+The demo must be run in an interactive terminal.
+
+## Controls
+
+From the main menu:
+
+* `1` — test cursor functionality
+* `2` — test foreground and background colors
+* `3` — test text attributes
+* `4` — test input events
+* `5` — test synchronized output
+* `q` — return to the main menu or exit the demo
+
+During most tests, press any other key to continue to the next step.


### PR DESCRIPTION
## Summary

Add the `README.md` referenced by `examples/interactive-demo/Cargo.toml`.

The README briefly explains the purpose of the interactive demo, how to run it, and the available controls.

## Motivation

The interactive demo's package manifest declares:

```toml
readme = "README.md"
```

but the referenced file does not currently exist.

This makes the package metadata inconsistent and can cause tools that inspect or vendor Cargo packages to fail while processing the repository. In particular, this surfaced while vendoring Crossterm as a Git dependency with Crane/Nix.

Adding the referenced file fixes the metadata at its source while also providing useful documentation for running the demo.

## Validation

The demo can be checked and run from the repository root with:

```sh
cargo check --manifest-path examples/interactive-demo/Cargo.toml
cargo run --manifest-path examples/interactive-demo/Cargo.toml
```
