### PR TITLE
Stop From<Colored> for Colors turning an underline color into a backg…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   bytes encoded the protocol origin (panic in debug, wrap to 65535
   in release). Affects `parse_csi_normal_mouse`, `parse_csi_rxvt_mouse`,
   `parse_csi_sgr_mouse`, and `parse_csi_cursor_position`.
+- Fix `Colors::from(Colored::UnderlineColor(_))` setting the background
+  color. `Colors` has no underline field, so the color is now dropped
+  instead of being applied to the background.
 
 # Version 0.29
 

--- a/src/style/types/colors.rs
+++ b/src/style/types/colors.rs
@@ -63,9 +63,12 @@ impl From<Colored> for Colors {
                 foreground: None,
                 background: Some(color),
             },
-            Colored::UnderlineColor(color) => Colors {
+            // `Colors` carries no underline color, so this one cannot be kept.
+            // Dropping it loses information, but putting it in `background`
+            // would apply a color the caller never asked for.
+            Colored::UnderlineColor(_) => Colors {
                 foreground: None,
-                background: Some(color),
+                background: None,
             },
         }
     }
@@ -73,7 +76,66 @@ impl From<Colored> for Colors {
 
 #[cfg(test)]
 mod tests {
-    use crate::style::{Color, Colors};
+    use crate::style::{Color, Colored, Colors};
+
+    #[test]
+    fn test_colors_from_colored() {
+        assert_eq!(
+            Colors::from(Colored::ForegroundColor(Color::Blue)),
+            Colors {
+                foreground: Some(Color::Blue),
+                background: None,
+            }
+        );
+
+        assert_eq!(
+            Colors::from(Colored::BackgroundColor(Color::Blue)),
+            Colors {
+                foreground: None,
+                background: Some(Color::Blue),
+            }
+        );
+
+        // there is no field to keep an underline color in, but it must not
+        // turn into a background color
+        assert_eq!(
+            Colors::from(Colored::UnderlineColor(Color::Blue)),
+            Colors {
+                foreground: None,
+                background: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_colors_from_parsed_underline_color() {
+        // SGR 58 sets an underline color, 59 resets it
+        let underline = Colored::parse_ansi("58;5;1").unwrap();
+        assert_eq!(underline, Colored::UnderlineColor(Color::DarkRed));
+        assert_eq!(
+            Colors::from(underline),
+            Colors {
+                foreground: None,
+                background: None,
+            }
+        );
+
+        let reset = Colored::parse_ansi("59").unwrap();
+        assert_eq!(reset, Colored::UnderlineColor(Color::Reset));
+        assert_eq!(
+            Colors::from(reset),
+            Colors {
+                foreground: None,
+                background: None,
+            }
+        );
+
+        // the pattern from the `Colors` doc example: reading a color out of a
+        // config must not repaint the background when that color is an
+        // underline color
+        let defaults = Colors::new(Color::Green, Color::Black);
+        assert_eq!(defaults.then(&underline.into()), defaults);
+    }
 
     #[test]
     fn test_colors_then() {


### PR DESCRIPTION
Fixes #1093

The `UnderlineColor` arm is byte identical to the `BackgroundColor` arm, so an underline color comes out as a background color:

```rust
Colored::BackgroundColor(color) => Colors { foreground: None, background: Some(color) },
Colored::UnderlineColor(color) => Colors { foreground: None, background: Some(color) },
```

That is reachable through the path the `Colors` docs advertise. `parse_ansi` returns `UnderlineColor` for SGR 58 and 59, and the doc example on `Colors` is parse-a-config-string then `.into()`, so `58;5;1` in a config repaints the background.

`Colors` only has `foreground` and `background`, so there is nowhere right to put an underline color. Dropping it loses the value, which is unavoidable given the type, but that beats applying a background the caller never asked for.

Two tests, one on the conversion itself and one going through `parse_ansi` and `then` the way the docs do. Both fail on master, reporting `background: Some(Blue)` and `background: Some(DarkRed)`.

`cargo test`, `cargo fmt --check` and `cargo clippy --all-targets` are all clean.