### PR TITLE
Fix Windows UTF-16 translation buffer size

### DIFF
--- a/src/event/sys/windows/parse.rs
+++ b/src/event/sys/windows/parse.rs
@@ -136,7 +136,7 @@ fn get_char_for_key(key_event: &KeyEventRecord) -> Option<char> {
     let virtual_key_code = key_event.virtual_key_code as u32;
     let virtual_scan_code = key_event.virtual_scan_code as u32;
     let key_state = [0u8; 256];
-    let mut utf16_buf = [0u16, 16];
+    let mut utf16_buf = [0u16; 16];
     let dont_change_kernel_keyboard_state = 0x4;
 
     // Best-effort attempt at determining the currently active keyboard layout.


### PR DESCRIPTION
Fixes #1092.

  `utf16_buf` was initialized as a two-element array (`[0u16, 16]`) while its length is passed to `ToUnicodeEx`. Initialize the intended 16-element zeroed buffer so translations requiring more than two UTF-16 code units
  have sufficient capacity.

  Tests:
  - `cargo fmt --all -- --check`
  - `cargo check --locked --lib --no-default-features --features windows,events`
  - `cargo clippy --locked --lib --no-default-features --features windows,events -- -D warnings`